### PR TITLE
[Fix] 중간보스몬스터 프리팹 수정 & 점프공격몬스터 로직 일부 수정

### DIFF
--- a/Assets/1.Public/Scripts/ScriptableObjects/Project Setting Installer.asset
+++ b/Assets/1.Public/Scripts/ScriptableObjects/Project Setting Installer.asset
@@ -38,6 +38,9 @@ MonoBehaviour:
         - Type: 4
           Prefab: {fileID: 4095791648714568686, guid: 7807ba7acaaa1244e99fa83fcb88e387,
             type: 3}
+        - Type: 5
+          Prefab: {fileID: 689508234494486168, guid: 6fc562c40b8210149bf2a8c32462c268,
+            type: 3}
     VFX:
       list:
         pairInfo:
@@ -261,17 +264,17 @@ MonoBehaviour:
       jumpDuration: 0
       changeSpeed: 1
     BossMobStat:
-      Health: 0
-      DamageReducation: 0
-      Damage: 0
-      Angle: 0
-      AttackRange: 0
-      MoveSpeed: 0
-      InAttackRange: 0
-      DetectRange: 0
-      RotateSpeed: 0
-      MaxRotateTime: 0
-      StopDist: 0
+      Health: 6000
+      DamageReducation: 1
+      Damage: 1
+      Angle: 90
+      AttackRange: 4
+      MoveSpeed: 2
+      InAttackRange: 4
+      DetectRange: 10
+      RotateSpeed: 5
+      MaxRotateTime: 2
+      StopDist: 1.5
       canJumpAttack: 0
       jumpHeight: 0
       jumpDuration: 0

--- a/Assets/2.Private/LimJH/Prefabs/BasicMonster.prefab
+++ b/Assets/2.Private/LimJH/Prefabs/BasicMonster.prefab
@@ -1051,6 +1051,7 @@ MonoBehaviour:
     jumpDuration: 0
     changeSpeed: 0
   type: 0
+  player: {fileID: 0}
   reference:
     Anim: {fileID: 8522007710125607252}
     Coll: {fileID: 8372804371624976041}

--- a/Assets/2.Private/LimJH/Prefabs/JumpMonster.prefab
+++ b/Assets/2.Private/LimJH/Prefabs/JumpMonster.prefab
@@ -247,6 +247,7 @@ MonoBehaviour:
     canJumpAttack: 0
     jumpHeight: 0
     jumpDuration: 0
+    changeSpeed: 0
   type: 3
   reference:
     Anim: {fileID: 5319549081127871000}

--- a/Assets/2.Private/LimJH/Prefabs/MidBossMonster.prefab
+++ b/Assets/2.Private/LimJH/Prefabs/MidBossMonster.prefab
@@ -1,0 +1,3343 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &249005703382577049
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2965209674911486853}
+  m_Layer: 0
+  m_Name: Bip001 L Toe0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2965209674911486853
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 249005703382577049}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.00000001545431, y: 0.00000001545431, z: -0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: -0.12434416, y: 0.19176374, z: -0.000000019073486}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4948198108665391316}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &299460202160763208
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8584060265816367028}
+  m_Layer: 0
+  m_Name: Bip001 Xtra01
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8584060265816367028
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 299460202160763208}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.47285056, y: 0.2611687, z: 0.49075583, w: 0.6836388}
+  m_LocalPosition: {x: -0.32095367, y: -0.000009063587, z: 0.000052232666}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5237970423658667716}
+  m_Father: {fileID: 6442779310939063138}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &331234425251777522
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6088068117176448003}
+  m_Layer: 0
+  m_Name: Bip001 R Finger42
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6088068117176448003
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 331234425251777522}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.000000015018946, y: 0.000000008168972, z: 0.0142325405,
+    w: 0.99989873}
+  m_LocalPosition: {x: -0.056423873, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5862968989670626362}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &383380693027410873
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 974108633279197108}
+  m_Layer: 0
+  m_Name: L B Skirt
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &974108633279197108
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 383380693027410873}
+  serializedVersion: 2
+  m_LocalRotation: {x: -4.461243e-14, y: 1.1368684e-13, z: -0.000000008368488, w: 1}
+  m_LocalPosition: {x: 0.17140876, y: -0.20073397, z: -0.19102964}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 669546694695729529}
+  m_Father: {fileID: 1198821136686639425}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &445232685031582243
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 669546694695729529}
+  m_Layer: 0
+  m_Name: Bone018
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &669546694695729529
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 445232685031582243}
+  serializedVersion: 2
+  m_LocalRotation: {x: -4.4612426e-14, y: -1.1368684e-13, z: 5.684342e-14, w: 1}
+  m_LocalPosition: {x: -0.19999999, y: -0.000000019073486, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 974108633279197108}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &563076890647570001
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 474952315651173261}
+  m_Layer: 0
+  m_Name: Bip001 R Clavicle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &474952315651173261
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 563076890647570001}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.6755902, y: 0.00026797125, z: 0.7372773, w: -0.0002944892}
+  m_LocalPosition: {x: -0.3193151, y: -0.00004294902, z: -0.15021524}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4511231928072316564}
+  m_Father: {fileID: 2845889884428407722}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &597701168504792637
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3402916946252044266}
+  m_Layer: 0
+  m_Name: R Hand Tiwst
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3402916946252044266
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 597701168504792637}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.82152903, y: 0.00000003139956, z: -0.0000017750348, w: 0.5701667}
+  m_LocalPosition: {x: -0.24122542, y: -0.000000095367426, z: -0.00000015258789}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 397709961399887672}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &649679571102810041
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6442779310939063138}
+  m_Layer: 0
+  m_Name: Bip001 Head
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6442779310939063138
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 649679571102810041}
+  serializedVersion: 2
+  m_LocalRotation: {x: -7.2656e-14, y: -0.0000000011042733, z: 0.00039883057, w: 0.99999994}
+  m_LocalPosition: {x: -0.067279354, y: 0, z: 2.842171e-16}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2679873972087643578}
+  - {fileID: 5265850012692082362}
+  - {fileID: 8584060265816367028}
+  - {fileID: 9212692374034424998}
+  - {fileID: 1507581381917849056}
+  - {fileID: 5027103228272867489}
+  - {fileID: 8188356208567778382}
+  m_Father: {fileID: 238114830536366571}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &689508234494486168
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3127956783737499808}
+  - component: {fileID: 4857124814140797786}
+  - component: {fileID: 833187138177631188}
+  - component: {fileID: 2773696281176814861}
+  - component: {fileID: 1012377218929762063}
+  - component: {fileID: 6203839926819243416}
+  - component: {fileID: 2515306666662830243}
+  m_Layer: 0
+  m_Name: MidBossMonster
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3127956783737499808
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 689508234494486168}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 2.35, y: 0, z: 0}
+  m_LocalScale: {x: 2.5, y: 2.5, z: 2.5}
+  m_ConstrainProportionsScale: 1
+  m_Children:
+  - {fileID: 212597263927930320}
+  - {fileID: 7348526932996667264}
+  - {fileID: 4791860882573393439}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!95 &4857124814140797786
+Animator:
+  serializedVersion: 5
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 689508234494486168}
+  m_Enabled: 1
+  m_Avatar: {fileID: 9000000, guid: 27a696dff64251a48808f2d4c8976e3c, type: 3}
+  m_Controller: {fileID: 9100000, guid: 11452cf45d8aa944c9e72abebe9d3200, type: 2}
+  m_CullingMode: 1
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 1
+  m_LinearVelocityBlending: 0
+  m_StabilizeFeet: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorStateOnDisable: 0
+  m_WriteDefaultValuesOnDisable: 0
+--- !u!114 &833187138177631188
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 689508234494486168}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 182c63670fb111a4796fd6f3e1fca938, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  projectilePrefab: {fileID: 0}
+  firePoint: {fileID: 0}
+  stat:
+    Health: 0
+    DamageReducation: 0
+    Damage: 0
+    Angle: 0
+    AttackRange: 0
+    MoveSpeed: 0
+    InAttackRange: 0
+    DetectRange: 0
+    RotateSpeed: 0
+    MaxRotateTime: 0
+    StopDist: 0
+    canJumpAttack: 0
+    jumpHeight: 0
+    jumpDuration: 0
+    changeSpeed: 0
+  type: 5
+  reference:
+    Anim: {fileID: 4857124814140797786}
+    Coll: {fileID: 2515306666662830243}
+    Rb: {fileID: 6203839926819243416}
+    Nav: {fileID: 1012377218929762063}
+  drag:
+    MaxDuration: 0
+    GatherSpeed: 0
+    GatherRad: 0
+  push:
+    MaxDuration: 0
+    PushDist: 0
+    PushSpeed: 0
+  knock:
+    DownDration: 0
+  attackCount: 0
+  RangedAttackDelay: 0
+  DashAttackDelay: 0
+  halfHealth: 0
+--- !u!114 &2773696281176814861
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 689508234494486168}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8d7b55c7ecdb49a4a89fa5e6f9022861, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  startWhenEnabled: 1
+  asynchronousLoad: 0
+  pauseWhenDisabled: 0
+  restartWhenComplete: 0
+  logTaskChanges: 0
+  group: 0
+  resetValuesOnRestart: 0
+  externalBehavior: {fileID: 0}
+  mBehaviorSource:
+    behaviorName: MidBossMonster
+    behaviorDescription: 
+    mTaskData:
+      types: []
+      parentIndex: 
+      startIndex: 
+      variableStartIndex: 
+      JSONSerialization: '{"EntryTask":{"Type":"BehaviorDesigner.Runtime.Tasks.EntryTask","NodeData":{"Offset":"(534.4,3.600006)"},"ID":0,"Name":"Entry","Instant":true},"RootTask":{"Type":"BehaviorDesigner.Runtime.Tasks.Repeater","NodeData":{"Offset":"(4.40002441,103.600006)"},"ID":1,"Name":"Repeater","Instant":true,"SharedIntcount":{"Type":"BehaviorDesigner.Runtime.SharedInt","Name":null,"Int32mValue":0},"SharedBoolrepeatForever":{"Type":"BehaviorDesigner.Runtime.SharedBool","Name":null,"BooleanmValue":true},"SharedBoolendOnFailure":{"Type":"BehaviorDesigner.Runtime.SharedBool","Name":null,"BooleanmValue":true},"Children":[{"Type":"BehaviorDesigner.Runtime.Tasks.Selector","NodeData":{"Offset":"(-3.20001221,102.400024)"},"ID":2,"Name":"Selector","Instant":true,"AbortTypeabortType":"LowerPriority","Children":[{"Type":"BehaviorDesigner.Runtime.Tasks.Sequence","NodeData":{"Offset":"(-857.6923,99.9037)"},"ID":3,"Name":"Sequence","Instant":true,"AbortTypeabortType":"LowerPriority","Children":[{"Type":"IsDead","NodeData":{"Offset":"(-244.499969,100.200073)"},"ID":4,"Name":"Is
+        Dead","Instant":true,"SharedGameObjectmy":{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":null}},{"Type":"InitializeCollider","NodeData":{"Offset":"(-115.299927,101.400024)"},"ID":5,"Name":"Initialize
+        Collider","Instant":true,"SharedGameObjectmy":{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":null}},{"Type":"BehaviorDesigner.Runtime.Tasks.Wait","NodeData":{"Offset":"(111.100037,101.400055)"},"ID":6,"Name":"Wait","Instant":true,"SharedFloatwaitTime":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":null,"SinglemValue":3},"SharedBoolrandomWait":{"Type":"BehaviorDesigner.Runtime.SharedBool","Name":null,"BooleanmValue":false},"SharedFloatrandomWaitMin":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":null,"SinglemValue":1},"SharedFloatrandomWaitMax":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":null,"SinglemValue":1}},{"Type":"Die","NodeData":{"Offset":"(215.100067,100.200012)"},"ID":7,"Name":"Die","Instant":true,"SharedGameObjectmy":{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":null}}]},{"Type":"BehaviorDesigner.Runtime.Tasks.Sequence","NodeData":{"Offset":"(-379.102844,98.37209)"},"ID":8,"Name":"Sequence","Instant":true,"AbortTypeabortType":"LowerPriority","Children":[{"Type":"IsCheckGroggy","NodeData":{"Offset":"(-77.8110657,103.200012)"},"ID":9,"Name":"Is
+        Check Groggy","Instant":true,"SharedBoolisGroggyActive":{"Type":"BehaviorDesigner.Runtime.SharedBool","Name":"IsGroggyActive","IsShared":true,"BooleanmValue":false},"SharedIntListpillarStates":{"Type":"SharedIntList","Name":"pillarStateList","IsShared":true,"List`1mValue":[0,0,0]}},{"Type":"MonsterGroggy","NodeData":{"Offset":"(69.19556,100.807091)"},"ID":10,"Name":"Monster
+        Groggy","Instant":true,"SharedBoolisGroggyActive":{"Type":"BehaviorDesigner.Runtime.SharedBool","Name":"IsGroggyActive","IsShared":true,"BooleanmValue":false},"SinglegroggyDuration":5}]},{"Type":"BehaviorDesigner.Runtime.Tasks.Sequence","NodeData":{"Offset":"(-109.127396,104.686653)"},"ID":11,"Name":"Sequence","Instant":true,"AbortTypeabortType":"LowerPriority","Children":[{"Type":"IsGimmickStart","NodeData":{"Offset":"(-62.8999634,103.200012)"},"ID":12,"Name":"Is
+        Gimmick Start","Instant":true,"SharedFloathealth":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":"health","IsShared":true,"SinglemValue":0},"SharedBoolisGimmickActive":{"Type":"BehaviorDesigner.Runtime.SharedBool","Name":"IsGimmickActive","IsShared":true,"BooleanmValue":false},"SharedFloathalfHealth":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":"halfHealth","IsShared":true,"SinglemValue":0}},{"Type":"GimmickFire","NodeData":{"Offset":"(67.9000244,100.200043)"},"ID":13,"Name":"Gimmick
+        Fire","Instant":true,"SharedGameObjecttargetObject":{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":"targetObject","IsShared":true},"SharedBoolisGimmickActive":{"Type":"BehaviorDesigner.Runtime.SharedBool","Name":"IsGimmickActive","IsShared":true,"BooleanmValue":false},"GameObjectfirePrefab":0,"GameObjectpillarPrefab":1,"SinglepillarSpawnRadius":5,"SharedFloatoriginalDamageReduction":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":null,"SinglemValue":0},"SharedIntListpillarStates":{"Type":"SharedIntList","Name":"pillarStateList","IsShared":true,"List`1mValue":[0,0,0]}}]},{"Type":"BehaviorDesigner.Runtime.Tasks.Sequence","NodeData":{"Offset":"(230.717468,102.620758)"},"ID":14,"Name":"Sequence","Instant":true,"AbortTypeabortType":"LowerPriority","Children":[{"Type":"IsInAttackRange","NodeData":{"Offset":"(-79.85724,104.689606)"},"ID":15,"Name":"Is
+        In Attack Range","Instant":true,"SharedGameObjectmy":{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":null}},{"Type":"BehaviorDesigner.Runtime.Tasks.Selector","NodeData":{"Offset":"(69.10831,106.758606)"},"ID":16,"Name":"Selector","Instant":true,"AbortTypeabortType":"LowerPriority","Children":[{"Type":"BehaviorDesigner.Runtime.Tasks.Sequence","NodeData":{"Offset":"(-264.613434,119.357994)"},"ID":17,"Name":"Sequence","Instant":true,"AbortTypeabortType":"LowerPriority","Children":[{"Type":"IsCheckAttackCount","NodeData":{"Offset":"(-83.70001,103.400024)"},"ID":18,"Name":"Is
+        Check Attack Count","Instant":true,"SharedIntattackCount":{"Type":"BehaviorDesigner.Runtime.SharedInt","Name":"attackCount","IsShared":true,"Int32mValue":0},"SharedIntspecialAttackCount":{"Type":"BehaviorDesigner.Runtime.SharedInt","Name":"specialAttackCount","IsShared":true,"Int32mValue":2},"SharedBoolisDelay":{"Type":"BehaviorDesigner.Runtime.SharedBool","Name":null,"BooleanmValue":false}},{"Type":"Attack","NodeData":{"Offset":"(67.38403,102.620544)"},"ID":19,"Name":"Attack","Instant":true,"SharedGameObjectmy":{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":null}},{"Type":"BehaviorDesigner.Runtime.Tasks.Wait","NodeData":{"Offset":"(189.570251,105.753845)"},"ID":20,"Name":"Wait","Instant":true,"SharedFloatwaitTime":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":null,"SinglemValue":1},"SharedBoolrandomWait":{"Type":"BehaviorDesigner.Runtime.SharedBool","Name":null,"BooleanmValue":false},"SharedFloatrandomWaitMin":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":null,"SinglemValue":1},"SharedFloatrandomWaitMax":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":null,"SinglemValue":1}}]},{"Type":"BehaviorDesigner.Runtime.Tasks.Sequence","NodeData":{"Offset":"(159.028427,132.620941)"},"ID":21,"Name":"Sequence","Instant":true,"AbortTypeabortType":"LowerPriority","Children":[{"Type":"IsCheckAttackCountS","NodeData":{"Offset":"(-83.75399,98.80005)"},"ID":22,"Name":"Is
+        Check Attack Count S","Instant":true,"SharedIntattackCount":{"Type":"BehaviorDesigner.Runtime.SharedInt","Name":"attackCount","IsShared":true,"Int32mValue":0},"SharedIntspecialAttackCount":{"Type":"BehaviorDesigner.Runtime.SharedInt","Name":"specialAttackCount","IsShared":true,"Int32mValue":2},"SharedBoolisDelay":{"Type":"BehaviorDesigner.Runtime.SharedBool","Name":null,"BooleanmValue":false}},{"Type":"BehaviorDesigner.Runtime.Tasks.Selector","NodeData":{"Offset":"(119.773438,100.716736)"},"ID":23,"Name":"Selector","Instant":true,"AbortTypeabortType":"None","Children":[{"Type":"BehaviorDesigner.Runtime.Tasks.Sequence","NodeData":{"Offset":"(-120.862534,97.0645447)"},"ID":24,"Name":"Sequence","Instant":true,"AbortTypeabortType":"None","Children":[{"Type":"IsWithinRanged","NodeData":{"Offset":"(-75.2441254,96.97219)"},"ID":25,"Name":"Is
+        Within Ranged","Instant":true,"SharedGameObjecttargetObject":{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":"targetObject","IsShared":true},"SharedGameObjectselfObject":{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":"selfObject","IsShared":true},"Singleranged":10},{"Type":"rangedAttack","NodeData":{"Offset":"(76.70682,97.86477)"},"ID":26,"Name":"Ranged
+        Attack","Instant":true,"SharedIntattackCount":{"Type":"BehaviorDesigner.Runtime.SharedInt","Name":"attackCount","IsShared":true,"Int32mValue":0},"SharedBoolisDelay":{"Type":"BehaviorDesigner.Runtime.SharedBool","Name":"isDelay","IsShared":true,"BooleanmValue":false}}]},{"Type":"BehaviorDesigner.Runtime.Tasks.Sequence","NodeData":{"Offset":"(166.0216,104.285751)"},"ID":27,"Name":"Sequence","Instant":true,"AbortTypeabortType":"None","Children":[{"Type":"IsWithindash","NodeData":{"Offset":"(-57.75856,104.772179)"},"ID":28,"Name":"Is
+        Withindash","Instant":true,"SharedGameObjecttargetObject":{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":"targetObject","IsShared":true},"SharedGameObjectselfObject":{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":"selfObject","IsShared":true},"SinglerangeThreshold":10},{"Type":"DashAttack","NodeData":{"Offset":"(59.7306137,97.86473)"},"ID":29,"Name":"Dash
+        Attack","Instant":true,"SharedGameObjecttargetObject":{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":"targetObject","IsShared":true},"SharedIntrushCount":{"Type":"BehaviorDesigner.Runtime.SharedInt","Name":null,"Int32mValue":0},"SharedIntattackCount":{"Type":"BehaviorDesigner.Runtime.SharedInt","Name":"attackCount","IsShared":true,"Int32mValue":0},"SharedFloatdashSpeed":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":null,"SinglemValue":2},"SharedFloatstopDistance":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":null,"SinglemValue":1},"SharedBoolisDelay":{"Type":"BehaviorDesigner.Runtime.SharedBool","Name":"isDelay","IsShared":true,"BooleanmValue":false},"SharedFloatattackRange":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":"attackRange","IsShared":true,"SinglemValue":1.5},"SharedFloatdetectRange":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":"detectRange","IsShared":true,"SinglemValue":5}},{"Type":"BehaviorDesigner.Runtime.Tasks.Wait","NodeData":{"Offset":"(173.0816,107.368469)"},"ID":30,"Name":"Wait","Instant":true,"SharedFloatwaitTime":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":null,"SinglemValue":1},"SharedBoolrandomWait":{"Type":"BehaviorDesigner.Runtime.SharedBool","Name":null,"BooleanmValue":false},"SharedFloatrandomWaitMin":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":null,"SinglemValue":1},"SharedFloatrandomWaitMax":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":null,"SinglemValue":1}}]}]}]}]}]},{"Type":"BehaviorDesigner.Runtime.Tasks.Sequence","NodeData":{"Offset":"(661.700867,96.20004)"},"ID":31,"Name":"Sequence","Instant":true,"AbortTypeabortType":"Both","Children":[{"Type":"IsWithinDistance","NodeData":{"Offset":"(-74.0999756,99.00006)"},"ID":32,"Name":"Is
+        Within Distance","Instant":true,"SharedGameObjectmy":{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":null}},{"Type":"FollowPlayer","NodeData":{"Offset":"(84.30005,99)"},"ID":33,"Name":"Follow
+        Player","Instant":true,"SharedGameObjectmy":{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":null}}]},{"Type":"Idle","NodeData":{"Offset":"(863.6905,102.600006)"},"ID":34,"Name":"Idle","Instant":true}]}]},"DetachedTasks":[{"Type":"BehaviorDesigner.Runtime.Tasks.Unity.UnityAnimator.Play","NodeData":{"Offset":"(-330.499939,401.400024)"},"ID":35,"Name":"Play","Instant":true,"SharedGameObjecttargetGameObject":{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":null},"SharedStringstateName":{"Type":"BehaviorDesigner.Runtime.SharedString","Name":null,"StringmValue":"Boss_Die"},"Int32layer":0,"SinglenormalizedTime":0}],"Variables":[{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":"targetObject","IsShared":true},{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":"selfObject","IsShared":true},{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":"health","IsShared":true,"SinglemValue":0},{"Type":"BehaviorDesigner.Runtime.SharedBool","Name":"IsGroggyActive","IsShared":true,"BooleanmValue":false},{"Type":"BehaviorDesigner.Runtime.SharedBool","Name":"IsGimmickActive","IsShared":true,"BooleanmValue":false},{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":"halfHealth","IsShared":true,"SinglemValue":0},{"Type":"SharedIntList","Name":"pillarStateList","IsShared":true,"List`1mValue":[0,0,0]},{"Type":"BehaviorDesigner.Runtime.SharedInt","Name":"attackCount","IsShared":true,"Int32mValue":0},{"Type":"BehaviorDesigner.Runtime.SharedInt","Name":"specialAttackCount","IsShared":true,"Int32mValue":2},{"Type":"BehaviorDesigner.Runtime.SharedBool","Name":"isDelay","IsShared":true,"BooleanmValue":false},{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":"attackRange","IsShared":true,"SinglemValue":1.5},{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":"detectRange","IsShared":true,"SinglemValue":5}]}'
+      fieldSerializationData:
+        typeName: []
+        fieldNameHash: 
+        startIndex: 
+        dataPosition: 
+        unityObjects:
+        - {fileID: 2247642504869527512, guid: 74bdd41d2fc7ce04da5aa131fd043fbb, type: 3}
+        - {fileID: 7631848718498701414, guid: 4e84ca981913b6e45822a2548f67d214, type: 3}
+        byteData: 
+        byteDataArray: 
+      Version: 1.7.11
+  gizmoViewMode: 2
+  showBehaviorDesignerGizmo: 1
+--- !u!195 &1012377218929762063
+NavMeshAgent:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 689508234494486168}
+  m_Enabled: 1
+  m_AgentTypeID: 0
+  m_Radius: 0.5
+  m_Speed: 3.5
+  m_Acceleration: 8
+  avoidancePriority: 50
+  m_AngularSpeed: 120
+  m_StoppingDistance: 0
+  m_AutoTraverseOffMeshLink: 1
+  m_AutoBraking: 1
+  m_AutoRepath: 1
+  m_Height: 2
+  m_BaseOffset: 0
+  m_WalkableMask: 4294967295
+  m_ObstacleAvoidanceType: 4
+--- !u!54 &6203839926819243416
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 689508234494486168}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 1
+  m_IsKinematic: 0
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!136 &2515306666662830243
+CapsuleCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 689508234494486168}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Radius: 0.5
+  m_Height: 2.0178099
+  m_Direction: 1
+  m_Center: {x: 0, y: 1.0017414, z: 0}
+--- !u!1 &712596138963445508
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8035617613294860509}
+  m_Layer: 0
+  m_Name: L F Skirt
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8035617613294860509
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 712596138963445508}
+  serializedVersion: 2
+  m_LocalRotation: {x: -3.5800284e-12, y: 2.2737362e-13, z: -5.6843405e-14, w: 1}
+  m_LocalPosition: {x: 0.17173782, y: 0.21374077, z: 0.19100004}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4599758856919989880}
+  m_Father: {fileID: 1198821136686639425}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &776243497440439375
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1453360986361614251}
+  m_Layer: 0
+  m_Name: R F Skirt
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1453360986361614251
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 776243497440439375}
+  serializedVersion: 2
+  m_LocalRotation: {x: 5.7950504e-14, y: 1.1368684e-13, z: -6.5882096e-27, w: 1}
+  m_LocalPosition: {x: 0.17173637, y: 0.2137425, z: -0.19102901}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 185845599789893112}
+  m_Father: {fileID: 1198821136686639425}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &783448701453267875
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9194645714249502714}
+  m_Layer: 0
+  m_Name: L Skirt
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &9194645714249502714
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 783448701453267875}
+  serializedVersion: 2
+  m_LocalRotation: {x: -1.21111975e-11, y: -1.0395204e-14, z: 0.00085831323, w: 0.99999964}
+  m_LocalPosition: {x: 0.17455795, y: -0.00000084168465, z: 0.34199953}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2006925824776340473}
+  m_Father: {fileID: 1198821136686639425}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &855293853491014975
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8502856973059074211}
+  m_Layer: 0
+  m_Name: IK Chain001
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8502856973059074211
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 855293853491014975}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.7071925, y: 0.00037099925, z: 0.7070206, w: -0.00076255144}
+  m_LocalPosition: {x: -0.36349937, y: 0.14696223, z: -0.0050861356}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6857009854509584227}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &870868929347974480
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1218038370509179743}
+  m_Layer: 0
+  m_Name: R B Skirt
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1218038370509179743
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 870868929347974480}
+  serializedVersion: 2
+  m_LocalRotation: {x: -6.171082e-13, y: 1.1368681e-13, z: -0.0000000018462738, w: 1}
+  m_LocalPosition: {x: 0.17141022, y: -0.20066465, z: 0.19099939}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3548906744314773157}
+  m_Father: {fileID: 1198821136686639425}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &904356566108021744
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7881191437684536024}
+  m_Layer: 0
+  m_Name: Bip001 L Finger12
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7881191437684536024
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 904356566108021744}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.0000000071847244, y: -0.000000018730605, z: 0.014232509,
+    w: 0.99989873}
+  m_LocalPosition: {x: -0.07234588, y: 0, z: -0.000000019073486}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7763353390198027075}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1078537771844913293
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6828120263684216621}
+  m_Layer: 0
+  m_Name: Bip001 L Finger41
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6828120263684216621
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1078537771844913293}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.0000000073378525, y: -0.0000000039426973, z: -0.029396, w: 0.99956787}
+  m_LocalPosition: {x: -0.05086227, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5965851140432261451}
+  m_Father: {fileID: 4643258908081832118}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1219295930176543175
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5552369949937841343}
+  m_Layer: 0
+  m_Name: IK Chain003
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5552369949937841343
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1219295930176543175}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.7070778, y: 0.006461107, z: 0.7070767, w: -0.006461117}
+  m_LocalPosition: {x: -0.3540908, y: -0.13322595, z: -0.0047372626}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6857009854509584227}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1245647513116869556
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4610492822393411051}
+  m_Layer: 0
+  m_Name: Bip001 R Finger22
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4610492822393411051
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1245647513116869556}
+  serializedVersion: 2
+  m_LocalRotation: {x: 2.6365046e-10, y: 0.000000005581712, z: -0.047182087, w: 0.9988863}
+  m_LocalPosition: {x: -0.080374144, y: -0.00000030517577, z: 0.000000057220458}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1099391473473260866}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1270186331456173701
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1527587368214869257}
+  m_Layer: 0
+  m_Name: Bip001 R Finger01
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1527587368214869257
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1270186331456173701}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.03570566, y: -0.079506174, z: -0.40811747, w: 0.9087596}
+  m_LocalPosition: {x: -0.09269024, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3101471652358960668}
+  m_Father: {fileID: 7686609791506948811}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1336384929625737697
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7763353390198027075}
+  m_Layer: 0
+  m_Name: Bip001 L Finger11
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7763353390198027075
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1336384929625737697}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.00000000783064, y: 0.000000012813863, z: -0.029395996, w: 0.99956787}
+  m_LocalPosition: {x: -0.0459787, y: -0.00000015258789, z: -0.000000038146972}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7881191437684536024}
+  m_Father: {fileID: 3400841045986185952}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1606445884942531557
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6876643356987049904}
+  m_Layer: 0
+  m_Name: R Dynamite Point
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6876643356987049904
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1606445884942531557}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.14127038, y: 0.18690659, z: 0.918245, w: -0.31927207}
+  m_LocalPosition: {x: -0.22190613, y: 0.084375605, z: 0.05478012}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8522574162186963932}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1732118891473145880
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1663383550251676031}
+  m_Layer: 0
+  m_Name: Bip001 L Finger3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1663383550251676031
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1732118891473145880}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.00039816648, y: 2.3208899e-10, z: 0.0000000018627377, w: 0.99999994}
+  m_LocalPosition: {x: -0.23560119, y: -0.005718841, z: 0.014014778}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2925290993305097613}
+  m_Father: {fileID: 5086364336980594610}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1741726017438950038
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8656627819494440258}
+  m_Layer: 0
+  m_Name: L Hand Twist
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8656627819494440258
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1741726017438950038}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.8215291, y: 0.00006663311, z: 0.0000040872574, w: 0.5701666}
+  m_LocalPosition: {x: -0.22000946, y: -0.0000051498414, z: -0.000004272461}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7357042632266849446}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1823368361945887165
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8522574162186963932}
+  m_Layer: 0
+  m_Name: Bip001 R Hand
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8522574162186963932
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1823368361945887165}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.8215291, y: -4.781929e-10, z: -3.318807e-10, w: 0.5701667}
+  m_LocalPosition: {x: -0.29076096, y: 0.000000019073486, z: 0.00000015258789}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6941994755752640974}
+  - {fileID: 7686609791506948811}
+  - {fileID: 2347834753381241116}
+  - {fileID: 1080350926894043776}
+  - {fileID: 1419757068373422616}
+  - {fileID: 1768455466301992447}
+  - {fileID: 6876643356987049904}
+  m_Father: {fileID: 397709961399887672}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1948870839430729937
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4599758856919989880}
+  m_Layer: 0
+  m_Name: Bone014
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4599758856919989880
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1948870839430729937}
+  serializedVersion: 2
+  m_LocalRotation: {x: 9.209741e-12, y: 2.2737368e-13, z: -2.0940526e-24, w: 1}
+  m_LocalPosition: {x: -0.20000008, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8035617613294860509}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1993301048952265845
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2395330758603202360}
+  m_Layer: 0
+  m_Name: Bip001 Pelvis
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2395330758603202360
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1993301048952265845}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.5, y: 0.5, z: 0.4999993, w: 0.5000007}
+  m_LocalPosition: {x: -0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6857009854509584227}
+  - {fileID: 6716683368987673365}
+  - {fileID: 3286454811351253851}
+  - {fileID: 1198821136686639425}
+  m_Father: {fileID: 212597263927930320}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2041012148495926652
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8188356208567778382}
+  m_Layer: 0
+  m_Name: Bip001 Xtra03
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8188356208567778382
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2041012148495926652}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.7804876, y: -0.62517124, z: -0.0000020938073, w: -0.00000047599875}
+  m_LocalPosition: {x: -0.06890808, y: 0.018425616, z: -0.00000020342729}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6442779310939063138}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2046510637902616664
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6857009854509584227}
+  m_Layer: 0
+  m_Name: Bip001 L Thigh
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6857009854509584227
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2046510637902616664}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.009138103, y: 0.9999583, z: -0.0000006858675, w: -0.0000006873064}
+  m_LocalPosition: {x: 0.00000022888183, y: 0.00000028648856, z: 0.18629238}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2675409124503939900}
+  - {fileID: 8502856973059074211}
+  - {fileID: 5552369949937841343}
+  - {fileID: 7891010359606668766}
+  m_Father: {fileID: 2395330758603202360}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2253045796318216257
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 881593168427474315}
+  m_Layer: 0
+  m_Name: Bip001 R Finger32
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &881593168427474315
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2253045796318216257}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: -0.029395979, w: 0.99956787}
+  m_LocalPosition: {x: -0.06331176, y: 0, z: 0.000000038146972}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2705307645217122275}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2392589460861587742
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2006925824776340473}
+  m_Layer: 0
+  m_Name: Bone008
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2006925824776340473
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2392589460861587742}
+  serializedVersion: 2
+  m_LocalRotation: {x: -3.1086245e-15, y: 1.1368684e-13, z: -5.820766e-11, w: 1}
+  m_LocalPosition: {x: -0.20000008, y: -0.000000038295983, z: 0.000000038146972}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 9194645714249502714}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2529545196203165232
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7902641268638038615}
+  m_Layer: 0
+  m_Name: IK Chain006
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7902641268638038615
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2529545196203165232}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.7070777, y: 0.006461114, z: 0.70707685, w: -0.0064611216}
+  m_LocalPosition: {x: -0.46865004, y: -0.00966592, z: 0.062707536}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6716683368987673365}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2556626334053563513
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1099391473473260866}
+  m_Layer: 0
+  m_Name: Bip001 R Finger21
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1099391473473260866
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2556626334053563513}
+  serializedVersion: 2
+  m_LocalRotation: {x: 3.037938e-10, y: 0.0000000065121766, z: -0.04659944, w: 0.99891365}
+  m_LocalPosition: {x: -0.050143432, y: 0.00000015258789, z: -0.000000057220458}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4610492822393411051}
+  m_Father: {fileID: 1080350926894043776}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2565474682613887303
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5496010274951664065}
+  m_Layer: 0
+  m_Name: Bip001 L Finger32
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5496010274951664065
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2565474682613887303}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: -0.029395986, w: 0.99956787}
+  m_LocalPosition: {x: -0.06331192, y: 0, z: -0.000000038146972}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2925290993305097613}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2831975702664370678
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2705307645217122275}
+  m_Layer: 0
+  m_Name: Bip001 R Finger31
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2705307645217122275
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2831975702664370678}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.000000014922097, y: 4.9288557e-10, z: -0.029395996, w: 0.99956787}
+  m_LocalPosition: {x: -0.05867241, y: 0.00000015258789, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 881593168427474315}
+  m_Father: {fileID: 1419757068373422616}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2843286099259112221
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5027103228272867489}
+  m_Layer: 0
+  m_Name: Bip001 Xtra02Opp
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5027103228272867489
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2843286099259112221}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.42116565, y: -0.33109435, z: 0.5205852, w: 0.6648211}
+  m_LocalPosition: {x: -0.13999313, y: -0.06774057, z: -0.08425795}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3539747206809483942}
+  m_Father: {fileID: 6442779310939063138}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2847084997365579725
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7348526932996667264}
+  - component: {fileID: 513277236942794260}
+  m_Layer: 0
+  m_Name: Bomb
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7348526932996667264
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2847084997365579725}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.000000021855694, y: 0, z: -0, w: 1}
+  m_LocalPosition: {x: -1.3116974e-10, y: 1.2620875, z: -0.45225227}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3127956783737499808}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &513277236942794260
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2847084997365579725}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a3397306a85145647b015dac2bc22536, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: -849867405023671905, guid: 27a696dff64251a48808f2d4c8976e3c, type: 3}
+  m_Bones:
+  - {fileID: 2845889884428407722}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 2845889884428407722}
+  m_AABB:
+    m_Center: {x: -0.09992522, y: -0.4521671, z: -0.000001013279}
+    m_Extent: {x: 0.57258713, y: 0.8278379, z: 0.5761739}
+  m_DirtyAABB: 0
+--- !u!1 &2892384089000010507
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4643258908081832118}
+  m_Layer: 0
+  m_Name: Bip001 L Finger4
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4643258908081832118
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2892384089000010507}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.00039665165, y: 0.08715576, z: -0.000034699246, w: 0.99619466}
+  m_LocalPosition: {x: -0.22222961, y: -0.005970306, z: 0.07065662}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6828120263684216621}
+  m_Father: {fileID: 5086364336980594610}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3132027011906579960
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5862968989670626362}
+  m_Layer: 0
+  m_Name: Bip001 R Finger41
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5862968989670626362
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3132027011906579960}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.000000014566194, y: -0.000000011609075, z: -0.029396003,
+    w: 0.99956787}
+  m_LocalPosition: {x: -0.05086227, y: 0, z: 0.000000038146972}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6088068117176448003}
+  m_Father: {fileID: 1768455466301992447}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3239959816864399063
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8659382307432982832}
+  m_Layer: 0
+  m_Name: Bip001 R Foot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8659382307432982832
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3239959816864399063}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.0000000059914553, y: -0.000000099640886, z: -0.047210995,
+    w: 0.998885}
+  m_LocalPosition: {x: -0.1374379, y: 0, z: 0.000000019073486}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3924878286633403926}
+  m_Father: {fileID: 8643446780133934221}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3434780021159145365
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1507581381917849056}
+  m_Layer: 0
+  m_Name: Bip001 Xtra02
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1507581381917849056
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3434780021159145365}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.32217613, y: 0.3290013, z: 0.67268795, w: 0.57918185}
+  m_LocalPosition: {x: -0.23137817, y: -0.047498956, z: 0.05502597}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5283615979974036418}
+  m_Father: {fileID: 6442779310939063138}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3613109965696297978
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 286893728511866186}
+  m_Layer: 0
+  m_Name: Bip001 L Finger01
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &286893728511866186
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3613109965696297978}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.03570568, y: 0.07950614, z: -0.4081175, w: 0.9087596}
+  m_LocalPosition: {x: -0.092690274, y: -0.000000076293944, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6129942244215129331}
+  m_Father: {fileID: 1251613915044979135}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3681393268046992874
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6941994755752640974}
+  m_Layer: 0
+  m_Name: BigBomb Point
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6941994755752640974
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3681393268046992874}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.5161608, y: -0.50306475, z: 0.40386713, w: 0.5633786}
+  m_LocalPosition: {x: -0.38285872, y: 0.5093844, z: 0.061259}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8522574162186963932}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3726716785075997867
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7116074617652499718}
+  m_Layer: 0
+  m_Name: R Forarm Twist
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7116074617652499718
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3726716785075997867}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.37614763, y: 0.000000016594749, z: -0.00000081084875, w: 0.9265598}
+  m_LocalPosition: {x: -0.0951699, y: 0.0014767647, z: -0.0021864318}
+  m_LocalScale: {x: 1, y: 1, z: 1.000001}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 397709961399887672}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3772475456362654970
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5552955771540650727}
+  m_Layer: 0
+  m_Name: L Forarm Twist
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5552955771540650727
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3772475456362654970}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.37614763, y: 0.000030394602, z: 0.00000196549, w: 0.9265598}
+  m_LocalPosition: {x: -0.08433792, y: 0.0015235138, z: 0.0020100402}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7357042632266849446}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &3939064725577299737
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1198821136686639425}
+  m_Layer: 0
+  m_Name: Point001
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1198821136686639425
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3939064725577299737}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.00000079812304, y: 1, z: -0.0000005642912, w: 0.00000039904282}
+  m_LocalPosition: {x: 0.003718109, y: 0.00000004768371, z: 0.000000038146972}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 974108633279197108}
+  - {fileID: 8035617613294860509}
+  - {fileID: 9194645714249502714}
+  - {fileID: 1218038370509179743}
+  - {fileID: 1453360986361614251}
+  - {fileID: 1405976563868482481}
+  m_Father: {fileID: 2395330758603202360}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4087648319022617521
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3101471652358960668}
+  m_Layer: 0
+  m_Name: Bip001 R Finger02
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3101471652358960668
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4087648319022617521}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.000000013932601, y: 0.000000009134462, z: -0.11640222, w: 0.9932022}
+  m_LocalPosition: {x: -0.06432762, y: 0, z: 0.00000015258789}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1527587368214869257}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4192199194932966060
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 212597263927930320}
+  m_Layer: 0
+  m_Name: Bip001
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &212597263927930320
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4192199194932966060}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.50000036, y: 0.49999964, z: 0.49999964, w: 0.50000036}
+  m_LocalPosition: {x: -0, y: 0.64372885, z: -0.000000015386858}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2395330758603202360}
+  m_Father: {fileID: 3127956783737499808}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4378223493045523614
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1419757068373422616}
+  m_Layer: 0
+  m_Name: Bip001 R Finger3
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1419757068373422616
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4378223493045523614}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.00039816654, y: -6.988627e-10, z: -9.310444e-10, w: 0.99999994}
+  m_LocalPosition: {x: -0.23560119, y: -0.005718994, z: -0.014014778}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2705307645217122275}
+  m_Father: {fileID: 8522574162186963932}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4408217842948127567
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7686609791506948811}
+  m_Layer: 0
+  m_Name: Bip001 R Finger0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7686609791506948811
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4408217842948127567}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.7164046, y: -0.5554529, z: -0.2139032, w: -0.3639807}
+  m_LocalPosition: {x: -0.105467066, y: 0.049133454, z: 0.11171871}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1527587368214869257}
+  m_Father: {fileID: 8522574162186963932}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4609534027760367924
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2197004027778752739}
+  m_Layer: 0
+  m_Name: Bip001 L Finger22
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2197004027778752739
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4609534027760367924}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.000000022063197, y: -0.0000000066363137, z: -0.04718208,
+    w: 0.9988863}
+  m_LocalPosition: {x: -0.080374144, y: -0.00000015258789, z: -0.000000076293944}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4922230845852271685}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4688284253250182850
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9211621511341180950}
+  m_Layer: 0
+  m_Name: Bip001 R Finger12
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &9211621511341180950
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4688284253250182850}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.000000007595632, y: -0.000000010137471, z: 0.014232506, w: 0.99989873}
+  m_LocalPosition: {x: -0.072345965, y: 0, z: -0.000000057220458}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1573855178053817509}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4840518558601264435
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5965851140432261451}
+  m_Layer: 0
+  m_Name: Bip001 L Finger42
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5965851140432261451
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4840518558601264435}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.000000015071969, y: 0.000000011893886, z: 0.014232542, w: 0.99989873}
+  m_LocalPosition: {x: -0.056423873, y: 0.00000015258789, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6828120263684216621}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4905005818430075986
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2845889884428407722}
+  m_Layer: 0
+  m_Name: Bip001 Spine1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2845889884428407722
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4905005818430075986}
+  serializedVersion: 2
+  m_LocalRotation: {x: -3.0117673e-14, y: 0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.35613272, y: -0.0002107726, z: -5.845993e-10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2363703575755423376}
+  - {fileID: 238114830536366571}
+  - {fileID: 474952315651173261}
+  m_Father: {fileID: 3286454811351253851}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4981593558475443468
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6716683368987673365}
+  m_Layer: 0
+  m_Name: Bip001 R Thigh
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6716683368987673365
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4981593558475443468}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.009138103, y: 0.9999583, z: -0.00000068740314, w: -0.0000007995276}
+  m_LocalPosition: {x: -0.00000022888183, y: -0.00000023021202, z: -0.18629238}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8643446780133934221}
+  - {fileID: 8760984143432069307}
+  - {fileID: 3097699426399968315}
+  - {fileID: 7902641268638038615}
+  m_Father: {fileID: 2395330758603202360}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5064273718166621517
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8760984143432069307}
+  m_Layer: 0
+  m_Name: IK Chain002
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8760984143432069307
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5064273718166621517}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.70713776, y: 0.00026124882, z: 0.7070754, w: -0.00068416016}
+  m_LocalPosition: {x: -0.36349943, y: 0.14696169, z: 0.004707756}
+  m_LocalScale: {x: 1, y: 1, z: 1.000001}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6716683368987673365}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5166278244178447780
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 397709961399887672}
+  m_Layer: 0
+  m_Name: Bip001 R Forearm
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &397709961399887672
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5166278244178447780}
+  serializedVersion: 2
+  m_LocalRotation: {x: -2.3717498e-11, y: 0.0000000018624942, z: 0.012733235, w: 0.99991894}
+  m_LocalPosition: {x: -0.4130112, y: 0.000000009536743, z: -0.00000015258789}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8522574162186963932}
+  - {fileID: 7116074617652499718}
+  - {fileID: 3402916946252044266}
+  m_Father: {fileID: 4511231928072316564}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5188439813733623012
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1251613915044979135}
+  m_Layer: 0
+  m_Name: Bip001 L Finger0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1251613915044979135
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5188439813733623012}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.7164046, y: -0.5554529, z: 0.21390323, w: 0.36398068}
+  m_LocalPosition: {x: -0.10546699, y: 0.049133454, z: -0.11171867}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 286893728511866186}
+  m_Father: {fileID: 5086364336980594610}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5284095009744314515
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 9212692374034424998}
+  m_Layer: 0
+  m_Name: Bip001 Xtra01Opp
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &9212692374034424998
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5284095009744314515}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.44394755, y: -0.16292559, z: 0.4673655, w: 0.7469507}
+  m_LocalPosition: {x: -0.31906065, y: -0.021542976, z: -0.03241113}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1024292077074244035}
+  m_Father: {fileID: 6442779310939063138}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5399668868682022953
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2679873972087643578}
+  m_Layer: 0
+  m_Name: Bip001 Glasses
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2679873972087643578
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5399668868682022953}
+  serializedVersion: 2
+  m_LocalRotation: {x: 1.4897102e-12, y: 0.0000020032257, z: -0.72224796, w: 0.6916343}
+  m_LocalPosition: {x: -0.19262879, y: 0.0015052888, z: -0.00000015376443}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6442779310939063138}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5482361215915085395
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3438058615030840428}
+  m_Layer: 0
+  m_Name: Bone010
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3438058615030840428
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5482361215915085395}
+  serializedVersion: 2
+  m_LocalRotation: {x: 1.9984014e-15, y: -1.1368684e-13, z: 2.2719194e-28, w: 1}
+  m_LocalPosition: {x: -0.20000003, y: -0.00000015318393, z: -0.000000038146972}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1405976563868482481}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5562621026962085695
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1573855178053817509}
+  m_Layer: 0
+  m_Name: Bip001 R Finger11
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1573855178053817509
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5562621026962085695}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.000000007967526, y: 0.000000017468464, z: -0.029395998, w: 0.99956787}
+  m_LocalPosition: {x: -0.045978468, y: -0.00000015258789, z: 0.000000076293944}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 9211621511341180950}
+  m_Father: {fileID: 2347834753381241116}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5635464042495667117
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 185845599789893112}
+  m_Layer: 0
+  m_Name: Bone012
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &185845599789893112
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5635464042495667117}
+  serializedVersion: 2
+  m_LocalRotation: {x: -5.573634e-14, y: -1.1368684e-13, z: 5.684342e-14, w: 1}
+  m_LocalPosition: {x: -0.20000015, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1453360986361614251}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5706596730029722924
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4791860882573393439}
+  - component: {fileID: 6208891247121626357}
+  m_Layer: 0
+  m_Name: Bomb_body
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4791860882573393439
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5706596730029722924}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
+  m_LocalPosition: {x: -0, y: 0, z: 0.0034931563}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 3127956783737499808}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!137 &6208891247121626357
+SkinnedMeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5706596730029722924}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 3
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a3397306a85145647b015dac2bc22536, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  serializedVersion: 2
+  m_Quality: 0
+  m_UpdateWhenOffscreen: 0
+  m_SkinnedMotionVectors: 1
+  m_Mesh: {fileID: -4161742498517634790, guid: 27a696dff64251a48808f2d4c8976e3c, type: 3}
+  m_Bones:
+  - {fileID: 6442779310939063138}
+  - {fileID: 2679873972087643578}
+  - {fileID: 5265850012692082362}
+  - {fileID: 474952315651173261}
+  - {fileID: 4511231928072316564}
+  - {fileID: 2845889884428407722}
+  - {fileID: 397709961399887672}
+  - {fileID: 5237970423658667716}
+  - {fileID: 5283615979974036418}
+  - {fileID: 3539747206809483942}
+  - {fileID: 5027103228272867489}
+  - {fileID: 6716683368987673365}
+  - {fileID: 2395330758603202360}
+  - {fileID: 1218038370509179743}
+  - {fileID: 974108633279197108}
+  - {fileID: 9194645714249502714}
+  - {fileID: 8035617613294860509}
+  - {fileID: 3286454811351253851}
+  - {fileID: 2363703575755423376}
+  - {fileID: 1453360986361614251}
+  - {fileID: 6857009854509584227}
+  - {fileID: 1405976563868482481}
+  - {fileID: 3993182602269951592}
+  - {fileID: 7357042632266849446}
+  - {fileID: 5552955771540650727}
+  - {fileID: 1024292077074244035}
+  - {fileID: 9212692374034424998}
+  - {fileID: 1507581381917849056}
+  - {fileID: 8584060265816367028}
+  - {fileID: 8643446780133934221}
+  - {fileID: 8659382307432982832}
+  - {fileID: 2675409124503939900}
+  - {fileID: 4948198108665391316}
+  - {fileID: 2965209674911486853}
+  - {fileID: 3924878286633403926}
+  - {fileID: 8188356208567778382}
+  - {fileID: 5086364336980594610}
+  - {fileID: 6956974237494678094}
+  - {fileID: 1663383550251676031}
+  - {fileID: 3400841045986185952}
+  - {fileID: 1251613915044979135}
+  - {fileID: 286893728511866186}
+  - {fileID: 4643258908081832118}
+  - {fileID: 6129942244215129331}
+  - {fileID: 8656627819494440258}
+  - {fileID: 7763353390198027075}
+  - {fileID: 6828120263684216621}
+  - {fileID: 7881191437684536024}
+  - {fileID: 5965851140432261451}
+  - {fileID: 4922230845852271685}
+  - {fileID: 2925290993305097613}
+  - {fileID: 2197004027778752739}
+  - {fileID: 5496010274951664065}
+  - {fileID: 8522574162186963932}
+  - {fileID: 1080350926894043776}
+  - {fileID: 1419757068373422616}
+  - {fileID: 2347834753381241116}
+  - {fileID: 7686609791506948811}
+  - {fileID: 1527587368214869257}
+  - {fileID: 1768455466301992447}
+  - {fileID: 3101471652358960668}
+  - {fileID: 3402916946252044266}
+  - {fileID: 1573855178053817509}
+  - {fileID: 5862968989670626362}
+  - {fileID: 9211621511341180950}
+  - {fileID: 6088068117176448003}
+  - {fileID: 1099391473473260866}
+  - {fileID: 2705307645217122275}
+  - {fileID: 4610492822393411051}
+  - {fileID: 881593168427474315}
+  - {fileID: 7116074617652499718}
+  m_BlendShapeWeights: []
+  m_RootBone: {fileID: 2395330758603202360}
+  m_AABB:
+    m_Center: {x: -0.4046793, y: 0.0034936368, z: 0.0000010728836}
+    m_Extent: {x: 1.0484083, y: 0.3376303, z: 1.4119784}
+  m_DirtyAABB: 0
+--- !u!1 &5838154457853152573
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3924878286633403926}
+  m_Layer: 0
+  m_Name: Bip001 R Toe0
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3924878286633403926
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5838154457853152573}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.000000015454312, y: -0.000000015454312, z: -0.7071068, w: 0.7071068}
+  m_LocalPosition: {x: -0.12434416, y: 0.19176376, z: -0.000000019073486}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8659382307432982832}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5861781203634681912
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8643446780133934221}
+  m_Layer: 0
+  m_Name: Bip001 R Calf
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8643446780133934221
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5861781203634681912}
+  serializedVersion: 2
+  m_LocalRotation: {x: 1.2317456e-13, y: -7.2831425e-15, z: 0.056336958, w: 0.99841183}
+  m_LocalPosition: {x: -0.37237224, y: 0, z: -0.000000019073486}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 8659382307432982832}
+  m_Father: {fileID: 6716683368987673365}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5906225342130855601
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3097699426399968315}
+  m_Layer: 0
+  m_Name: IK Chain004
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3097699426399968315
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5906225342130855601}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.70707756, y: 0.006461168, z: 0.70707697, w: -0.006461174}
+  m_LocalPosition: {x: -0.35409072, y: -0.1332265, z: 0.004707413}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6716683368987673365}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5921128532034670837
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4922230845852271685}
+  m_Layer: 0
+  m_Name: Bip001 L Finger21
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4922230845852271685
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5921128532034670837}
+  serializedVersion: 2
+  m_LocalRotation: {x: -2.603946e-10, y: -0.0000000055818643, z: -0.046599433, w: 0.99891365}
+  m_LocalPosition: {x: -0.050143506, y: 0.00000030517577, z: 0.000000057220458}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2197004027778752739}
+  m_Father: {fileID: 6956974237494678094}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5949470801526904200
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3286454811351253851}
+  m_Layer: 0
+  m_Name: Bip001 Spine
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3286454811351253851
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5949470801526904200}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.000002080476, y: 0.000000693676, z: -0.000398159, w: 0.99999994}
+  m_LocalPosition: {x: -0.1617405, y: -0.0002835442, z: 0.00000022469489}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2845889884428407722}
+  m_Father: {fileID: 2395330758603202360}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &5981750155725668214
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 238114830536366571}
+  m_Layer: 0
+  m_Name: Bip001 Neck
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &238114830536366571
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5981750155725668214}
+  serializedVersion: 2
+  m_LocalRotation: {x: -3.0117673e-14, y: 0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.31883827, y: -0.000053570493, z: -1.4858642e-10}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 6442779310939063138}
+  m_Father: {fileID: 2845889884428407722}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6092005379978431488
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1080350926894043776}
+  m_Layer: 0
+  m_Name: Bip001 R Finger2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1080350926894043776
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6092005379978431488}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.00038369832, y: 0.07319349, z: -0.00015340002, w: 0.9973177}
+  m_LocalPosition: {x: -0.23423706, y: -0.0058799745, z: 0.047029264}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1099391473473260866}
+  m_Father: {fileID: 8522574162186963932}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6176954729115586271
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4948198108665391316}
+  m_Layer: 0
+  m_Name: Bip001 L Foot
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4948198108665391316
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6176954729115586271}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.0000000018640782, y: 0.000000012315572, z: -0.047210995,
+    w: 0.998885}
+  m_LocalPosition: {x: -0.13743788, y: 0, z: 0.000000019073486}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2965209674911486853}
+  m_Father: {fileID: 2675409124503939900}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6195902040602155968
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1024292077074244035}
+  m_Layer: 0
+  m_Name: Bip001 Xtra01Opp02
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1024292077074244035
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6195902040602155968}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.000000014901159, y: 0.000000011175871, z: -0.000000014901161,
+    w: 1}
+  m_LocalPosition: {x: -0.16820617, y: -0.0001234436, z: 0.000000038146972}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 9212692374034424998}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6203789893149748740
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3539747206809483942}
+  m_Layer: 0
+  m_Name: Bip001 Xtra02Opp02
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3539747206809483942
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6203789893149748740}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.000000003317837, y: 0.000000009240466, z: 0.000000014901161,
+    w: 1}
+  m_LocalPosition: {x: -0.15520783, y: -0.00012374877, z: -0.000000011920928}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5027103228272867489}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6463307560499599774
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6956974237494678094}
+  m_Layer: 0
+  m_Name: Bip001 L Finger2
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6956974237494678094
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6463307560499599774}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.00038369818, y: -0.0731935, z: -0.0001533986, w: 0.9973177}
+  m_LocalPosition: {x: -0.23423699, y: -0.0058799745, z: -0.047029227}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4922230845852271685}
+  m_Father: {fileID: 5086364336980594610}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6582937728444233953
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2363703575755423376}
+  m_Layer: 0
+  m_Name: Bip001 L Clavicle
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2363703575755423376
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6582937728444233953}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.6755902, y: -0.00027001614, z: 0.7372773, w: -0.00029261538}
+  m_LocalPosition: {x: -0.3193151, y: -0.000043782293, z: 0.15021524}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3993182602269951592}
+  m_Father: {fileID: 2845889884428407722}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6614337551748752458
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7357042632266849446}
+  m_Layer: 0
+  m_Name: Bip001 L Forearm
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7357042632266849446
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6614337551748752458}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.0000000037131294, y: -9.78682e-10, z: 0.012733234, w: 0.99991894}
+  m_LocalPosition: {x: -0.43708163, y: 0, z: 0.00000015258789}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5086364336980594610}
+  - {fileID: 5552955771540650727}
+  - {fileID: 8656627819494440258}
+  m_Father: {fileID: 3993182602269951592}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6671287470121182879
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3344484624261618468}
+  m_Layer: 0
+  m_Name: L Dynamite Point
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3344484624261618468
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6671287470121182879}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.9246787, y: -0.35854056, z: -0.12744659, w: -0.013245872}
+  m_LocalPosition: {x: -0.22937812, y: 0.09192352, z: -0.07251034}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5086364336980594610}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6845085611286711815
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2675409124503939900}
+  m_Layer: 0
+  m_Name: Bip001 L Calf
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2675409124503939900
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6845085611286711815}
+  serializedVersion: 2
+  m_LocalRotation: {x: 4.2271582e-14, y: -2.8353327e-16, z: 0.056336958, w: 0.99841183}
+  m_LocalPosition: {x: -0.3723722, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 4948198108665391316}
+  m_Father: {fileID: 6857009854509584227}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &6876020711392332026
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4511231928072316564}
+  m_Layer: 0
+  m_Name: Bip001 R UpperArm
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4511231928072316564
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6876020711392332026}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.049909048, y: -0.034223244, z: -0.0026473373, w: 0.99816376}
+  m_LocalPosition: {x: -0.11661768, y: 3.6379787e-14, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 397709961399887672}
+  m_Father: {fileID: 474952315651173261}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7039361299306355265
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5237970423658667716}
+  m_Layer: 0
+  m_Name: Bip001 Xtra0102
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5237970423658667716
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7039361299306355265}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.0000000037252899, y: 0.0000000037252903, z: -1.3877786e-17,
+    w: 1}
+  m_LocalPosition: {x: -0.1682061, y: -0.00012359618, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8584060265816367028}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7212011709894495419
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1768455466301992447}
+  m_Layer: 0
+  m_Name: Bip001 R Finger4
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1768455466301992447
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7212011709894495419}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.00039665136, y: -0.08715575, z: -0.000034703015, w: 0.99619466}
+  m_LocalPosition: {x: -0.22222969, y: -0.005970306, z: -0.07065657}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5862968989670626362}
+  m_Father: {fileID: 8522574162186963932}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7248213237443727738
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5265850012692082362}
+  m_Layer: 0
+  m_Name: Bip001 Ponytail1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5265850012692082362
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7248213237443727738}
+  serializedVersion: 2
+  m_LocalRotation: {x: 1.7026289e-12, y: 0.0000022364788, z: -0.8063454, w: 0.591445}
+  m_LocalPosition: {x: -0.07126373, y: 0.011714527, z: -0.0000001393956}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6442779310939063138}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &7551116811596586467
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6129942244215129331}
+  m_Layer: 0
+  m_Name: Bip001 L Finger02
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6129942244215129331
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7551116811596586467}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.000000015450313, y: -0.0000000038154218, z: -0.11640222,
+    w: 0.9932022}
+  m_LocalPosition: {x: -0.06432762, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 286893728511866186}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8024791074691530553
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3548906744314773157}
+  m_Layer: 0
+  m_Name: Bone016
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3548906744314773157
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8024791074691530553}
+  serializedVersion: 2
+  m_LocalRotation: {x: 6.501364e-14, y: 1.1368684e-13, z: -7.391195e-27, w: 1}
+  m_LocalPosition: {x: -0.2000001, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1218038370509179743}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8097880240279404008
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2925290993305097613}
+  m_Layer: 0
+  m_Name: Bip001 L Finger31
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2925290993305097613
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8097880240279404008}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.0000000074199833, y: 0.0000000011499374, z: -0.029395998,
+    w: 0.99956787}
+  m_LocalPosition: {x: -0.058672257, y: 0.00000015258789, z: -0.000000038146972}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 5496010274951664065}
+  m_Father: {fileID: 1663383550251676031}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8162191803831144317
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7891010359606668766}
+  m_Layer: 0
+  m_Name: IK Chain005
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7891010359606668766
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8162191803831144317}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.7070778, y: 0.0064611505, z: 0.7070767, w: -0.0064611603}
+  m_LocalPosition: {x: -0.46864995, y: -0.009665223, z: -0.06276544}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 6857009854509584227}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8265590350477037670
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3993182602269951592}
+  m_Layer: 0
+  m_Name: Bip001 L UpperArm
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3993182602269951592
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8265590350477037670}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.049909048, y: 0.034223244, z: -0.0026473373, w: 0.99816376}
+  m_LocalPosition: {x: -0.11661768, y: 3.6379787e-14, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7357042632266849446}
+  m_Father: {fileID: 2363703575755423376}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8595909782531365800
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3400841045986185952}
+  m_Layer: 0
+  m_Name: Bip001 L Finger1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3400841045986185952
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8595909782531365800}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0.0037361307, y: -0.13307528, z: -0.030698003, w: 0.99062335}
+  m_LocalPosition: {x: -0.22077331, y: -0.00006744385, z: -0.11148243}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7763353390198027075}
+  m_Father: {fileID: 5086364336980594610}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8695306937045677181
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5086364336980594610}
+  m_Layer: 0
+  m_Name: Bip001 L Hand
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5086364336980594610
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8695306937045677181}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.8215291, y: 0.0000000010520242, z: -7.3013745e-10, w: 0.5701667}
+  m_LocalPosition: {x: -0.26911741, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1251613915044979135}
+  - {fileID: 3400841045986185952}
+  - {fileID: 6956974237494678094}
+  - {fileID: 1663383550251676031}
+  - {fileID: 4643258908081832118}
+  - {fileID: 3344484624261618468}
+  m_Father: {fileID: 7357042632266849446}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8781128848054646588
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1405976563868482481}
+  m_Layer: 0
+  m_Name: R Skirt
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1405976563868482481
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8781128848054646588}
+  serializedVersion: 2
+  m_LocalRotation: {x: -2.9694522e-10, y: -0.000000041446853, z: 0.0008582198, w: 0.99999964}
+  m_LocalPosition: {x: 0.17455597, y: 0.00000027221182, z: -0.34213766}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3438058615030840428}
+  m_Father: {fileID: 1198821136686639425}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &8806310436908692603
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5283615979974036418}
+  m_Layer: 0
+  m_Name: Bip001 Xtra0202
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5283615979974036418
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8806310436908692603}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.0000000037252903, y: -0.000000015133992, z: 0.0000000037252903,
+    w: 1}
+  m_LocalPosition: {x: -0.1552078, y: -0.0001234436, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1507581381917849056}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &9109703761852490345
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2347834753381241116}
+  m_Layer: 0
+  m_Name: Bip001 R Finger1
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2347834753381241116
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9109703761852490345}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.0037361297, y: 0.13307531, z: -0.030698003, w: 0.99062335}
+  m_LocalPosition: {x: -0.22077338, y: -0.00006759643, z: 0.1114825}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1573855178053817509}
+  m_Father: {fileID: 8522574162186963932}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/2.Private/LimJH/Prefabs/MidBossMonster.prefab.meta
+++ b/Assets/2.Private/LimJH/Prefabs/MidBossMonster.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6fc562c40b8210149bf2a8c32462c268
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/2.Private/LimJH/Scenes/FixScene/FixTest1.unity
+++ b/Assets/2.Private/LimJH/Scenes/FixScene/FixTest1.unity
@@ -454,854 +454,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   type: 0
---- !u!1001 &379252664
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 36587642971040777, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 6.135386
-      objectReference: {fileID: 0}
-    - target: {fileID: 36587642971040777, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -92.787544
-      objectReference: {fileID: 0}
-    - target: {fileID: 36587642971040777, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -140.74483
-      objectReference: {fileID: 0}
-    - target: {fileID: 228870514926186557, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -0.000005387327
-      objectReference: {fileID: 0}
-    - target: {fileID: 228870514926186557, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -0.0015930105
-      objectReference: {fileID: 0}
-    - target: {fileID: 228870514926186557, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -61.332478
-      objectReference: {fileID: 0}
-    - target: {fileID: 586081393947292781, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0.00015203022
-      objectReference: {fileID: 0}
-    - target: {fileID: 586081393947292781, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -0.008176411
-      objectReference: {fileID: 0}
-    - target: {fileID: 586081393947292781, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -61.352985
-      objectReference: {fileID: 0}
-    - target: {fileID: 715668025585149133, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -9.45926
-      objectReference: {fileID: 0}
-    - target: {fileID: 715668025585149133, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 177.33757
-      objectReference: {fileID: 0}
-    - target: {fileID: 715668025585149133, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -65.36147
-      objectReference: {fileID: 0}
-    - target: {fileID: 922170798615243539, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -0.61118907
-      objectReference: {fileID: 0}
-    - target: {fileID: 922170798615243539, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 4.8853717
-      objectReference: {fileID: 0}
-    - target: {fileID: 922170798615243539, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -0.16092888
-      objectReference: {fileID: 0}
-    - target: {fileID: 1038830337580621997, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 15.565456
-      objectReference: {fileID: 0}
-    - target: {fileID: 1038830337580621997, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 3.3965943
-      objectReference: {fileID: 0}
-    - target: {fileID: 1038830337580621997, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -12.630887
-      objectReference: {fileID: 0}
-    - target: {fileID: 1208009223231000806, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -81.500046
-      objectReference: {fileID: 0}
-    - target: {fileID: 1208009223231000806, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -0.0000020561283
-      objectReference: {fileID: 0}
-    - target: {fileID: 1208009223231000806, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 13.290777
-      objectReference: {fileID: 0}
-    - target: {fileID: 1237284750648481252, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 9.053007
-      objectReference: {fileID: 0}
-    - target: {fileID: 1237284750648481252, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -102.35314
-      objectReference: {fileID: 0}
-    - target: {fileID: 1237284750648481252, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -151.84128
-      objectReference: {fileID: 0}
-    - target: {fileID: 1438029090715128830, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -4.975389
-      objectReference: {fileID: 0}
-    - target: {fileID: 1438029090715128830, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 1.1498039
-      objectReference: {fileID: 0}
-    - target: {fileID: 1438029090715128830, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -40.970966
-      objectReference: {fileID: 0}
-    - target: {fileID: 1510967059057246366, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 23.72724
-      objectReference: {fileID: 0}
-    - target: {fileID: 1510967059057246366, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -90.84665
-      objectReference: {fileID: 0}
-    - target: {fileID: 1510967059057246366, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -19.336292
-      objectReference: {fileID: 0}
-    - target: {fileID: 1527417071103117936, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 1.8092608
-      objectReference: {fileID: 0}
-    - target: {fileID: 1527417071103117936, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -91.68764
-      objectReference: {fileID: 0}
-    - target: {fileID: 1527417071103117936, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 38.1326
-      objectReference: {fileID: 0}
-    - target: {fileID: 1560860381930841345, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -0.008236326
-      objectReference: {fileID: 0}
-    - target: {fileID: 1560860381930841345, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 5.7586594
-      objectReference: {fileID: 0}
-    - target: {fileID: 1560860381930841345, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0.43156183
-      objectReference: {fileID: 0}
-    - target: {fileID: 1724399007777182143, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -0.0000041266703
-      objectReference: {fileID: 0}
-    - target: {fileID: 1724399007777182143, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0.0015788117
-      objectReference: {fileID: 0}
-    - target: {fileID: 1724399007777182143, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -61.332478
-      objectReference: {fileID: 0}
-    - target: {fileID: 1885773436489284649, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -0.0000025506126
-      objectReference: {fileID: 0}
-    - target: {fileID: 1885773436489284649, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0.0000028202003
-      objectReference: {fileID: 0}
-    - target: {fileID: 1885773436489284649, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 155.84874
-      objectReference: {fileID: 0}
-    - target: {fileID: 2931865986201117865, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -11.242657
-      objectReference: {fileID: 0}
-    - target: {fileID: 2931865986201117865, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -8.183052
-      objectReference: {fileID: 0}
-    - target: {fileID: 2931865986201117865, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -32.385624
-      objectReference: {fileID: 0}
-    - target: {fileID: 2993233121950863020, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -6.4640026
-      objectReference: {fileID: 0}
-    - target: {fileID: 2993233121950863020, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -25.555948
-      objectReference: {fileID: 0}
-    - target: {fileID: 2993233121950863020, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -12.365863
-      objectReference: {fileID: 0}
-    - target: {fileID: 3273264999423536653, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0.10611625
-      objectReference: {fileID: 0}
-    - target: {fileID: 3273264999423536653, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0.9873239
-      objectReference: {fileID: 0}
-    - target: {fileID: 3273264999423536653, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -7.006704
-      objectReference: {fileID: 0}
-    - target: {fileID: 3318558335282059371, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -15.672762
-      objectReference: {fileID: 0}
-    - target: {fileID: 3318558335282059371, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -8.249709
-      objectReference: {fileID: 0}
-    - target: {fileID: 3318558335282059371, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -92.155556
-      objectReference: {fileID: 0}
-    - target: {fileID: 3320133666274923054, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -0.0000042403594
-      objectReference: {fileID: 0}
-    - target: {fileID: 3320133666274923054, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0.0000064313062
-      objectReference: {fileID: 0}
-    - target: {fileID: 3320133666274923054, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0.0000018375184
-      objectReference: {fileID: 0}
-    - target: {fileID: 3815875145615529599, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0.7427752
-      objectReference: {fileID: 0}
-    - target: {fileID: 3815875145615529599, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 179.95665
-      objectReference: {fileID: 0}
-    - target: {fileID: 3815875145615529599, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -25.155197
-      objectReference: {fileID: 0}
-    - target: {fileID: 3909529323239521884, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -1.1738445
-      objectReference: {fileID: 0}
-    - target: {fileID: 3909529323239521884, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 5.2060666
-      objectReference: {fileID: 0}
-    - target: {fileID: 3909529323239521884, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 9.416516
-      objectReference: {fileID: 0}
-    - target: {fileID: 4044259921605878590, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 12.69341
-      objectReference: {fileID: 0}
-    - target: {fileID: 4044259921605878590, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -99.79103
-      objectReference: {fileID: 0}
-    - target: {fileID: 4044259921605878590, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -134.44644
-      objectReference: {fileID: 0}
-    - target: {fileID: 4095791648714568686, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_Name
-      value: BombMonster
-      objectReference: {fileID: 0}
-    - target: {fileID: 4095791648714568686, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_IsActive
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 4289201013929934604, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0.84035707
-      objectReference: {fileID: 0}
-    - target: {fileID: 4289201013929934604, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -1.6140172
-      objectReference: {fileID: 0}
-    - target: {fileID: 4289201013929934604, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 85.08278
-      objectReference: {fileID: 0}
-    - target: {fileID: 4434860706298411557, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 34.14036
-      objectReference: {fileID: 0}
-    - target: {fileID: 4434860706298411557, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 4.3540354
-      objectReference: {fileID: 0}
-    - target: {fileID: 4434860706298411557, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -120.30875
-      objectReference: {fileID: 0}
-    - target: {fileID: 4459779163761904868, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 1.3014703
-      objectReference: {fileID: 0}
-    - target: {fileID: 4459779163761904868, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -8.91434
-      objectReference: {fileID: 0}
-    - target: {fileID: 4459779163761904868, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 28.814384
-      objectReference: {fileID: 0}
-    - target: {fileID: 4648709553107329908, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -0.69391775
-      objectReference: {fileID: 0}
-    - target: {fileID: 4648709553107329908, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -82.83403
-      objectReference: {fileID: 0}
-    - target: {fileID: 4648709553107329908, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -146.51569
-      objectReference: {fileID: 0}
-    - target: {fileID: 4733664791646059167, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -0.69391775
-      objectReference: {fileID: 0}
-    - target: {fileID: 4733664791646059167, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -82.83403
-      objectReference: {fileID: 0}
-    - target: {fileID: 4733664791646059167, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -146.51569
-      objectReference: {fileID: 0}
-    - target: {fileID: 4786542527274724619, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -1.3337107
-      objectReference: {fileID: 0}
-    - target: {fileID: 4786542527274724619, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -0.4518169
-      objectReference: {fileID: 0}
-    - target: {fileID: 4786542527274724619, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -19.114706
-      objectReference: {fileID: 0}
-    - target: {fileID: 5121830637829557337, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -0.0000018375147
-      objectReference: {fileID: 0}
-    - target: {fileID: 5121830637829557337, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -95
-      objectReference: {fileID: 0}
-    - target: {fileID: 5121830637829557337, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -90.00001
-      objectReference: {fileID: 0}
-    - target: {fileID: 5230953164525931814, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -7.648135
-      objectReference: {fileID: 0}
-    - target: {fileID: 5230953164525931814, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 175.05183
-      objectReference: {fileID: 0}
-    - target: {fileID: 5230953164525931814, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -13.898673
-      objectReference: {fileID: 0}
-    - target: {fileID: 5486767246881285819, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -0.647767
-      objectReference: {fileID: 0}
-    - target: {fileID: 5486767246881285819, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 1.6677169
-      objectReference: {fileID: 0}
-    - target: {fileID: 5486767246881285819, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 14.839075
-      objectReference: {fileID: 0}
-    - target: {fileID: 5724397078778648731, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0.000001830514
-      objectReference: {fileID: 0}
-    - target: {fileID: 5724397078778648731, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -0.000007350058
-      objectReference: {fileID: 0}
-    - target: {fileID: 5724397078778648731, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -0.0000018375191
-      objectReference: {fileID: 0}
-    - target: {fileID: 6065996722142072803, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -3.98065
-      objectReference: {fileID: 0}
-    - target: {fileID: 6065996722142072803, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalPosition.y
-      value: -0.0000009536743
-      objectReference: {fileID: 0}
-    - target: {fileID: 6065996722142072803, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalPosition.z
-      value: -11.321676
-      objectReference: {fileID: 0}
-    - target: {fileID: 6065996722142072803, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6065996722142072803, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6065996722142072803, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6065996722142072803, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6065996722142072803, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6065996722142072803, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6065996722142072803, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6131463510187157185, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -0.0000018375147
-      objectReference: {fileID: 0}
-    - target: {fileID: 6131463510187157185, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -86
-      objectReference: {fileID: 0}
-    - target: {fileID: 6131463510187157185, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -90.00001
-      objectReference: {fileID: 0}
-    - target: {fileID: 6167058666346564930, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 4.628029
-      objectReference: {fileID: 0}
-    - target: {fileID: 6167058666346564930, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -0.96271026
-      objectReference: {fileID: 0}
-    - target: {fileID: 6167058666346564930, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -17.451435
-      objectReference: {fileID: 0}
-    - target: {fileID: 6628528757740565223, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -5.2050357
-      objectReference: {fileID: 0}
-    - target: {fileID: 6628528757740565223, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -0.612716
-      objectReference: {fileID: 0}
-    - target: {fileID: 6628528757740565223, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -36.51877
-      objectReference: {fileID: 0}
-    - target: {fileID: 6656506560040518757, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 11.345528
-      objectReference: {fileID: 0}
-    - target: {fileID: 6656506560040518757, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -89.85179
-      objectReference: {fileID: 0}
-    - target: {fileID: 6656506560040518757, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 18.789658
-      objectReference: {fileID: 0}
-    - target: {fileID: 6662968624884590778, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6662968624884590778, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -85.49999
-      objectReference: {fileID: 0}
-    - target: {fileID: 6662968624884590778, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -90.00001
-      objectReference: {fileID: 0}
-    - target: {fileID: 6716644186976233088, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 5.8855658
-      objectReference: {fileID: 0}
-    - target: {fileID: 6716644186976233088, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -4.0756702
-      objectReference: {fileID: 0}
-    - target: {fileID: 6716644186976233088, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -18.218481
-      objectReference: {fileID: 0}
-    - target: {fileID: 6833208757098907835, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 3.363764
-      objectReference: {fileID: 0}
-    - target: {fileID: 6833208757098907835, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0.031123996
-      objectReference: {fileID: 0}
-    - target: {fileID: 6833208757098907835, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -1.0905904
-      objectReference: {fileID: 0}
-    - target: {fileID: 6867160052085367978, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -1.9752035
-      objectReference: {fileID: 0}
-    - target: {fileID: 6867160052085367978, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 2.2978408
-      objectReference: {fileID: 0}
-    - target: {fileID: 6867160052085367978, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 13.324713
-      objectReference: {fileID: 0}
-    - target: {fileID: 7352474288349998058, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -0.00000048814616
-      objectReference: {fileID: 0}
-    - target: {fileID: 7352474288349998058, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0.0018923904
-      objectReference: {fileID: 0}
-    - target: {fileID: 7352474288349998058, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -61.371807
-      objectReference: {fileID: 0}
-    - target: {fileID: 7419183404444314764, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 11.459316
-      objectReference: {fileID: 0}
-    - target: {fileID: 7419183404444314764, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -1.6400031
-      objectReference: {fileID: 0}
-    - target: {fileID: 7419183404444314764, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -16.628765
-      objectReference: {fileID: 0}
-    - target: {fileID: 7430228916857448239, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 7430228916857448239, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -94.50001
-      objectReference: {fileID: 0}
-    - target: {fileID: 7430228916857448239, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -90.00001
-      objectReference: {fileID: 0}
-    - target: {fileID: 7537562447353540574, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0.000004240375
-      objectReference: {fileID: 0}
-    - target: {fileID: 7537562447353540574, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -0.0000036750291
-      objectReference: {fileID: 0}
-    - target: {fileID: 7537562447353540574, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0.0000018375117
-      objectReference: {fileID: 0}
-    - target: {fileID: 7926906361045642135, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 16.270275
-      objectReference: {fileID: 0}
-    - target: {fileID: 7926906361045642135, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 2.9213731
-      objectReference: {fileID: 0}
-    - target: {fileID: 7926906361045642135, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 106.371544
-      objectReference: {fileID: 0}
-    - target: {fileID: 7980570801343017247, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 5.092491
-      objectReference: {fileID: 0}
-    - target: {fileID: 7980570801343017247, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0.4195032
-      objectReference: {fileID: 0}
-    - target: {fileID: 7980570801343017247, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -24.028261
-      objectReference: {fileID: 0}
-    - target: {fileID: 8223059316530152280, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 4.151477
-      objectReference: {fileID: 0}
-    - target: {fileID: 8223059316530152280, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -91.00319
-      objectReference: {fileID: 0}
-    - target: {fileID: 8223059316530152280, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 36.32164
-      objectReference: {fileID: 0}
-    - target: {fileID: 8316666109973781147, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0.0000018375147
-      objectReference: {fileID: 0}
-    - target: {fileID: 8316666109973781147, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -90.00001
-      objectReference: {fileID: 0}
-    - target: {fileID: 8602490694106546152, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: -0.000004178793
-      objectReference: {fileID: 0}
-    - target: {fileID: 8602490694106546152, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -0.0000004593783
-      objectReference: {fileID: 0}
-    - target: {fileID: 8602490694106546152, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0.0000036750232
-      objectReference: {fileID: 0}
-    - target: {fileID: 8907175629585560215, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 39.034405
-      objectReference: {fileID: 0}
-    - target: {fileID: 8907175629585560215, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -90.538315
-      objectReference: {fileID: 0}
-    - target: {fileID: 8907175629585560215, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -32.450565
-      objectReference: {fileID: 0}
-    - target: {fileID: 9043067859818824736, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 19.094683
-      objectReference: {fileID: 0}
-    - target: {fileID: 9043067859818824736, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -161.56647
-      objectReference: {fileID: 0}
-    - target: {fileID: 9043067859818824736, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -39.08509
-      objectReference: {fileID: 0}
-    - target: {fileID: 9079109684070456894, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 10.9866295
-      objectReference: {fileID: 0}
-    - target: {fileID: 9079109684070456894, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: -4.8943715
-      objectReference: {fileID: 0}
-    - target: {fileID: 9079109684070456894, guid: 7807ba7acaaa1244e99fa83fcb88e387,
-        type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: -38.671307
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 7807ba7acaaa1244e99fa83fcb88e387, type: 3}
 --- !u!1 &564919244
 GameObject:
   m_ObjectHideFlags: 0
@@ -1394,6 +546,7 @@ Transform:
   - {fileID: 743578627}
   - {fileID: 564919245}
   - {fileID: 37767888}
+  - {fileID: 2086373687}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &743578626
@@ -1956,6 +1109,315 @@ Transform:
   - {fileID: 120621441}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2002474790
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2002474798}
+  - component: {fileID: 2002474797}
+  - component: {fileID: 2002474796}
+  - component: {fileID: 2002474795}
+  - component: {fileID: 2002474794}
+  - component: {fileID: 2002474793}
+  - component: {fileID: 2002474792}
+  - component: {fileID: 2002474791}
+  m_Layer: 0
+  m_Name: MidBossMonster
+  m_TagString: Monster
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!114 &2002474791
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2002474790}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 182c63670fb111a4796fd6f3e1fca938, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  projectilePrefab: {fileID: 0}
+  firePoint: {fileID: 0}
+  stat:
+    Health: 0
+    DamageReducation: 0
+    Damage: 0
+    Angle: 0
+    AttackRange: 0
+    MoveSpeed: 0
+    InAttackRange: 0
+    DetectRange: 0
+    RotateSpeed: 0
+    MaxRotateTime: 0
+    StopDist: 0
+    canJumpAttack: 0
+    jumpHeight: 0
+    jumpDuration: 0
+    changeSpeed: 0
+  type: -1
+  reference:
+    Anim: {fileID: 0}
+    Coll: {fileID: 0}
+    Rb: {fileID: 0}
+    Nav: {fileID: 0}
+  drag:
+    MaxDuration: 0
+    GatherSpeed: 0
+    GatherRad: 0
+  push:
+    MaxDuration: 0
+    PushDist: 0
+    PushSpeed: 0
+  knock:
+    DownDration: 0
+  attackCount: 0
+  RangedAttackDelay: 1
+  DashAttackDelay: 1
+  halfHealth: 0
+--- !u!54 &2002474792
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2002474790}
+  serializedVersion: 4
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_CenterOfMass: {x: 0, y: 0, z: 0}
+  m_InertiaTensor: {x: 1, y: 1, z: 1}
+  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ImplicitCom: 1
+  m_ImplicitTensor: 1
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!195 &2002474793
+NavMeshAgent:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2002474790}
+  m_Enabled: 1
+  m_AgentTypeID: 0
+  m_Radius: 0.5
+  m_Speed: 3.5
+  m_Acceleration: 8
+  avoidancePriority: 50
+  m_AngularSpeed: 120
+  m_StoppingDistance: 0
+  m_AutoTraverseOffMeshLink: 1
+  m_AutoBraking: 1
+  m_AutoRepath: 1
+  m_Height: 1
+  m_BaseOffset: 0.5
+  m_WalkableMask: 4294967295
+  m_ObstacleAvoidanceType: 4
+--- !u!114 &2002474794
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2002474790}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8d7b55c7ecdb49a4a89fa5e6f9022861, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  startWhenEnabled: 1
+  asynchronousLoad: 0
+  pauseWhenDisabled: 0
+  restartWhenComplete: 0
+  logTaskChanges: 0
+  group: 0
+  resetValuesOnRestart: 0
+  externalBehavior: {fileID: 0}
+  mBehaviorSource:
+    behaviorName: MidBossMonster
+    behaviorDescription: 
+    mTaskData:
+      types: []
+      parentIndex: 
+      startIndex: 
+      variableStartIndex: 
+      JSONSerialization: '{"EntryTask":{"Type":"BehaviorDesigner.Runtime.Tasks.EntryTask","NodeData":{"Offset":"(534.4,3.600006)"},"ID":0,"Name":"Entry","Instant":true},"RootTask":{"Type":"BehaviorDesigner.Runtime.Tasks.Repeater","NodeData":{"Offset":"(4.40002441,103.600006)"},"ID":1,"Name":"Repeater","Instant":true,"SharedIntcount":{"Type":"BehaviorDesigner.Runtime.SharedInt","Name":null,"Int32mValue":0},"SharedBoolrepeatForever":{"Type":"BehaviorDesigner.Runtime.SharedBool","Name":null,"BooleanmValue":true},"SharedBoolendOnFailure":{"Type":"BehaviorDesigner.Runtime.SharedBool","Name":null,"BooleanmValue":true},"Children":[{"Type":"BehaviorDesigner.Runtime.Tasks.Selector","NodeData":{"Offset":"(-3.20001221,102.400024)"},"ID":2,"Name":"Selector","Instant":true,"AbortTypeabortType":"LowerPriority","Children":[{"Type":"BehaviorDesigner.Runtime.Tasks.Sequence","NodeData":{"Offset":"(-667.6923,99.9037)"},"ID":3,"Name":"Sequence","Instant":true,"AbortTypeabortType":"LowerPriority","Children":[{"Type":"IsDead","NodeData":{"Offset":"(-64.49997,100.200073)"},"ID":4,"Name":"Is
+        Dead","Instant":true,"SharedFloathealth":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":"health","IsShared":true,"SinglemValue":0}},{"Type":"Die","NodeData":{"Offset":"(55.1000671,100.200012)"},"ID":5,"Name":"Die","Instant":true,"SharedFloathealth":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":"health","IsShared":true,"SinglemValue":0},"SharedGameObjectselfObject":{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":"selfObject","IsShared":true}}]},{"Type":"BehaviorDesigner.Runtime.Tasks.Sequence","NodeData":{"Offset":"(-379.102844,98.37209)"},"ID":6,"Name":"Sequence","Instant":true,"AbortTypeabortType":"LowerPriority","Children":[{"Type":"IsCheckGroggy","NodeData":{"Offset":"(-77.8110657,103.200012)"},"ID":7,"Name":"Is
+        Check Groggy","Instant":true,"SharedBoolisGroggyActive":{"Type":"BehaviorDesigner.Runtime.SharedBool","Name":"IsGroggyActive","IsShared":true,"BooleanmValue":false},"SharedIntListpillarStates":{"Type":"SharedIntList","Name":"pillarStateList","IsShared":true,"List`1mValue":[0,0,0]}},{"Type":"MonsterGroggy","NodeData":{"Offset":"(69.19556,100.807091)"},"ID":8,"Name":"Monster
+        Groggy","Instant":true,"SharedBoolisGroggyActive":{"Type":"BehaviorDesigner.Runtime.SharedBool","Name":"IsGroggyActive","IsShared":true,"BooleanmValue":false},"SinglegroggyDuration":5}]},{"Type":"BehaviorDesigner.Runtime.Tasks.Sequence","NodeData":{"Offset":"(-109.127396,104.686653)"},"ID":9,"Name":"Sequence","Instant":true,"AbortTypeabortType":"LowerPriority","Children":[{"Type":"IsGimmickStart","NodeData":{"Offset":"(-62.8999634,103.200012)"},"ID":10,"Name":"Is
+        Gimmick Start","Instant":true,"SharedFloathealth":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":"health","IsShared":true,"SinglemValue":0},"SharedBoolisGimmickActive":{"Type":"BehaviorDesigner.Runtime.SharedBool","Name":"IsGimmickActive","IsShared":true,"BooleanmValue":false},"SharedFloathalfHealth":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":"halfHealth","IsShared":true,"SinglemValue":0}},{"Type":"GimmickFire","NodeData":{"Offset":"(67.9000244,100.200043)"},"ID":11,"Name":"Gimmick
+        Fire","Instant":true,"SharedGameObjecttargetObject":{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":"targetObject","IsShared":true},"SharedBoolisGimmickActive":{"Type":"BehaviorDesigner.Runtime.SharedBool","Name":"IsGimmickActive","IsShared":true,"BooleanmValue":false},"GameObjectfirePrefab":0,"GameObjectpillarPrefab":1,"SinglepillarSpawnRadius":5,"SharedFloatoriginalDamageReduction":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":null,"SinglemValue":0},"SharedIntListpillarStates":{"Type":"SharedIntList","Name":"pillarStateList","IsShared":true,"List`1mValue":[0,0,0]}}]},{"Type":"BehaviorDesigner.Runtime.Tasks.Sequence","NodeData":{"Offset":"(230.717468,102.620758)"},"ID":12,"Name":"Sequence","Instant":true,"AbortTypeabortType":"LowerPriority","Children":[{"Type":"IsInAttackRange","NodeData":{"Offset":"(-79.85724,104.689606)"},"ID":13,"Name":"Is
+        In Attack Range","Instant":true,"SharedGameObjectselfObject":{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":"selfObject","IsShared":true},"SharedGameObjecttargetObject":{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":"targetObject","IsShared":true},"SharedFloatattackRange":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":"attackRange","IsShared":true,"SinglemValue":1.5}},{"Type":"BehaviorDesigner.Runtime.Tasks.Selector","NodeData":{"Offset":"(69.10831,106.758606)"},"ID":14,"Name":"Selector","Instant":true,"AbortTypeabortType":"LowerPriority","Children":[{"Type":"BehaviorDesigner.Runtime.Tasks.Sequence","NodeData":{"Offset":"(-264.613434,119.357994)"},"ID":15,"Name":"Sequence","Instant":true,"AbortTypeabortType":"LowerPriority","Children":[{"Type":"IsCheckAttackCount","NodeData":{"Offset":"(-83.70001,103.400024)"},"ID":16,"Name":"Is
+        Check Attack Count","Instant":true,"SharedIntattackCount":{"Type":"BehaviorDesigner.Runtime.SharedInt","Name":"attackCount","IsShared":true,"Int32mValue":0},"SharedIntspecialAttackCount":{"Type":"BehaviorDesigner.Runtime.SharedInt","Name":"specialAttackCount","IsShared":true,"Int32mValue":2},"SharedBoolisDelay":{"Type":"BehaviorDesigner.Runtime.SharedBool","Name":null,"BooleanmValue":false}},{"Type":"Attack","NodeData":{"Offset":"(67.38403,102.620544)"},"ID":17,"Name":"Attack","Instant":true,"SharedGameObjectselfObject":{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":null},"SharedGameObjecttargetObject":{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":"targetObject","IsShared":true}},{"Type":"BehaviorDesigner.Runtime.Tasks.Wait","NodeData":{"Offset":"(189.570251,105.753845)"},"ID":18,"Name":"Wait","Instant":true,"SharedFloatwaitTime":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":null,"SinglemValue":1},"SharedBoolrandomWait":{"Type":"BehaviorDesigner.Runtime.SharedBool","Name":null,"BooleanmValue":false},"SharedFloatrandomWaitMin":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":null,"SinglemValue":1},"SharedFloatrandomWaitMax":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":null,"SinglemValue":1}}]},{"Type":"BehaviorDesigner.Runtime.Tasks.Sequence","NodeData":{"Offset":"(159.028427,132.620941)"},"ID":19,"Name":"Sequence","Instant":true,"AbortTypeabortType":"LowerPriority","Children":[{"Type":"IsCheckAttackCountS","NodeData":{"Offset":"(-83.75399,98.80005)"},"ID":20,"Name":"Is
+        Check Attack Count S","Instant":true,"SharedIntattackCount":{"Type":"BehaviorDesigner.Runtime.SharedInt","Name":"attackCount","IsShared":true,"Int32mValue":0},"SharedIntspecialAttackCount":{"Type":"BehaviorDesigner.Runtime.SharedInt","Name":"specialAttackCount","IsShared":true,"Int32mValue":2},"SharedBoolisDelay":{"Type":"BehaviorDesigner.Runtime.SharedBool","Name":null,"BooleanmValue":false}},{"Type":"BehaviorDesigner.Runtime.Tasks.Selector","NodeData":{"Offset":"(119.773438,100.716736)"},"ID":21,"Name":"Selector","Instant":true,"AbortTypeabortType":"None","Children":[{"Type":"BehaviorDesigner.Runtime.Tasks.Sequence","NodeData":{"Offset":"(-120.862534,97.0645447)"},"ID":22,"Name":"Sequence","Instant":true,"AbortTypeabortType":"None","Children":[{"Type":"IsWithinRanged","NodeData":{"Offset":"(-75.2441254,96.97219)"},"ID":23,"Name":"Is
+        Within Ranged","Instant":true,"SharedGameObjecttargetObject":{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":"targetObject","IsShared":true},"SharedGameObjectselfObject":{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":"selfObject","IsShared":true},"Singleranged":10},{"Type":"rangedAttack","NodeData":{"Offset":"(76.70682,97.86477)"},"ID":24,"Name":"Ranged
+        Attack","Instant":true,"SharedIntattackCount":{"Type":"BehaviorDesigner.Runtime.SharedInt","Name":"attackCount","IsShared":true,"Int32mValue":0},"SharedBoolisDelay":{"Type":"BehaviorDesigner.Runtime.SharedBool","Name":"isDelay","IsShared":true,"BooleanmValue":false}}]},{"Type":"BehaviorDesigner.Runtime.Tasks.Sequence","NodeData":{"Offset":"(166.0216,104.285751)"},"ID":25,"Name":"Sequence","Instant":true,"AbortTypeabortType":"None","Children":[{"Type":"IsWithindash","NodeData":{"Offset":"(-57.75856,104.772179)"},"ID":26,"Name":"Is
+        Withindash","Instant":true,"SharedGameObjecttargetObject":{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":"targetObject","IsShared":true},"SharedGameObjectselfObject":{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":"selfObject","IsShared":true},"SinglerangeThreshold":10},{"Type":"DashAttack","NodeData":{"Offset":"(59.7306137,97.86473)"},"ID":27,"Name":"Dash
+        Attack","Instant":true,"SharedGameObjecttargetObject":{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":"targetObject","IsShared":true},"SharedIntrushCount":{"Type":"BehaviorDesigner.Runtime.SharedInt","Name":null,"Int32mValue":0},"SharedIntattackCount":{"Type":"BehaviorDesigner.Runtime.SharedInt","Name":"attackCount","IsShared":true,"Int32mValue":0},"SharedFloatdashSpeed":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":null,"SinglemValue":2},"SharedFloatstopDistance":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":null,"SinglemValue":1},"SharedBoolisDelay":{"Type":"BehaviorDesigner.Runtime.SharedBool","Name":"isDelay","IsShared":true,"BooleanmValue":false},"SharedFloatattackRange":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":"attackRange","IsShared":true,"SinglemValue":1.5},"SharedFloatdetectRange":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":"detectRange","IsShared":true,"SinglemValue":5}},{"Type":"BehaviorDesigner.Runtime.Tasks.Wait","NodeData":{"Offset":"(187.36731,107.368469)"},"ID":28,"Name":"Wait","Instant":true,"SharedFloatwaitTime":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":null,"SinglemValue":1},"SharedBoolrandomWait":{"Type":"BehaviorDesigner.Runtime.SharedBool","Name":null,"BooleanmValue":false},"SharedFloatrandomWaitMin":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":null,"SinglemValue":1},"SharedFloatrandomWaitMax":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":null,"SinglemValue":1}}]}]}]}]}]},{"Type":"BehaviorDesigner.Runtime.Tasks.Sequence","NodeData":{"Offset":"(661.700867,96.20004)"},"ID":29,"Name":"Sequence","Instant":true,"AbortTypeabortType":"Both","Children":[{"Type":"IsWithinDistance","NodeData":{"Offset":"(-74.0999756,99.00006)"},"ID":30,"Name":"Is
+        Within Distance","Instant":true,"SharedGameObjectselfObject":{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":"selfObject","IsShared":true},"SharedGameObjecttargetObject":{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":"targetObject","IsShared":true},"SharedFloatdetectRange":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":"detectRange","IsShared":true,"SinglemValue":5}},{"Type":"FollowPlayer","NodeData":{"Offset":"(84.30005,99)"},"ID":31,"Name":"Follow
+        Player","Instant":true,"SharedGameObjectselfObject":{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":"selfObject","IsShared":true},"SharedGameObjecttargetObject":{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":"targetObject","IsShared":true},"SharedFloatspeed":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":null,"SinglemValue":3},"SharedFloatstoppingDistance":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":null,"SinglemValue":1.5}}]},{"Type":"Idle","NodeData":{"Offset":"(863.6905,102.600006)"},"ID":32,"Name":"Idle","Instant":true}]}]},"Variables":[{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":"targetObject","IsShared":true},{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":"selfObject","IsShared":true},{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":"health","IsShared":true,"SinglemValue":0},{"Type":"BehaviorDesigner.Runtime.SharedBool","Name":"IsGroggyActive","IsShared":true,"BooleanmValue":false},{"Type":"BehaviorDesigner.Runtime.SharedBool","Name":"IsGimmickActive","IsShared":true,"BooleanmValue":false},{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":"halfHealth","IsShared":true,"SinglemValue":0},{"Type":"SharedIntList","Name":"pillarStateList","IsShared":true,"List`1mValue":[0,0,0]},{"Type":"BehaviorDesigner.Runtime.SharedInt","Name":"attackCount","IsShared":true,"Int32mValue":0},{"Type":"BehaviorDesigner.Runtime.SharedInt","Name":"specialAttackCount","IsShared":true,"Int32mValue":2},{"Type":"BehaviorDesigner.Runtime.SharedBool","Name":"isDelay","IsShared":true,"BooleanmValue":false},{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":"attackRange","IsShared":true,"SinglemValue":1.5},{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":"detectRange","IsShared":true,"SinglemValue":5}]}'
+      fieldSerializationData:
+        typeName: []
+        fieldNameHash: 
+        startIndex: 
+        dataPosition: 
+        unityObjects:
+        - {fileID: 2247642504869527512, guid: 74bdd41d2fc7ce04da5aa131fd043fbb, type: 3}
+        - {fileID: 7631848718498701414, guid: 4e84ca981913b6e45822a2548f67d214, type: 3}
+        byteData: 
+        byteDataArray: 
+      Version: 1.7.11
+  gizmoViewMode: 2
+  showBehaviorDesignerGizmo: 1
+--- !u!65 &2002474795
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2002474790}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!23 &2002474796
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2002474790}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: f9a009e65238aac4bb53fde2832a5ee5, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!33 &2002474797
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2002474790}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!4 &2002474798
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2002474790}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -4.1, y: 0.5, z: 5.61}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2086373686
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2086373687}
+  - component: {fileID: 2086373688}
+  m_Layer: 0
+  m_Name: MonsterCreate (5)
+  m_TagString: Untagged
+  m_Icon: {fileID: 7174288486110832750, guid: 0000000000000000d000000000000000, type: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &2086373687
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2086373686}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.1, y: 0, z: 8.27}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 733339011}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2086373688
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2086373686}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fea8b46711a53dd4da307c7b4d04fb8d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  type: 5
 --- !u!224 &3279227527858447
 RectTransform:
   m_ObjectHideFlags: 0
@@ -2037,23 +1499,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &67145891722817889
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 920601596048554334}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.6755902, y: 0.00026797125, z: 0.7372773, w: -0.00029448923}
-  m_LocalPosition: {x: -0.2759648, y: -0.08085112, z: -0.052867446}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2869327454000615801}
-  - {fileID: 6837384140312721178}
-  m_Father: {fileID: 7208229995167400711}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!224 &68617352031220985
 RectTransform:
   m_ObjectHideFlags: 0
@@ -2122,26 +1567,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!4 &86253843048717131
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1956380190279898641}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.706812, y: 0.057182718, z: 0.004440451, w: 0.70507246}
-  m_LocalPosition: {x: -0.36577553, y: -0.000000038146972, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1533557749198662978}
-  - {fileID: 1801176966041713716}
-  - {fileID: 2255631131416199291}
-  - {fileID: 2960015648610644071}
-  - {fileID: 2455183032975858917}
-  m_Father: {fileID: 7628904877610385984}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &88570307656217045
 GameObject:
   m_ObjectHideFlags: 0
@@ -2910,29 +2335,6 @@ RectTransform:
   m_AnchoredPosition: {x: 468, y: 0}
   m_SizeDelta: {x: 450, y: 230}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!136 &333899169111128897
-CapsuleCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3519210703361510015}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 2
-  m_Radius: 0.5
-  m_Height: 2.0178099
-  m_Direction: 1
-  m_Center: {x: 0, y: 1.0017414, z: 0}
 --- !u!114 &345857081274658024
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3124,52 +2526,6 @@ MonoBehaviour:
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []
---- !u!114 &415924105689620363
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3519210703361510015}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 8d7b55c7ecdb49a4a89fa5e6f9022861, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  startWhenEnabled: 1
-  asynchronousLoad: 0
-  pauseWhenDisabled: 0
-  restartWhenComplete: 0
-  logTaskChanges: 0
-  group: 0
-  resetValuesOnRestart: 0
-  externalBehavior: {fileID: 0}
-  mBehaviorSource:
-    behaviorName: EliteMonsterBehavior1
-    behaviorDescription: 
-    mTaskData:
-      types: []
-      parentIndex: 
-      startIndex: 
-      variableStartIndex: 
-      JSONSerialization: '{"EntryTask":{"Type":"BehaviorDesigner.Runtime.Tasks.EntryTask","NodeData":{"Offset":"(534.4,3.600006)"},"ID":0,"Name":"Entry","Instant":true},"RootTask":{"Type":"BehaviorDesigner.Runtime.Tasks.Repeater","NodeData":{"Offset":"(4.40002441,103.600006)"},"ID":1,"Name":"Repeater","Instant":true,"SharedIntcount":{"Type":"BehaviorDesigner.Runtime.SharedInt","Name":null,"Int32mValue":0},"SharedBoolrepeatForever":{"Type":"BehaviorDesigner.Runtime.SharedBool","Name":null,"BooleanmValue":true},"SharedBoolendOnFailure":{"Type":"BehaviorDesigner.Runtime.SharedBool","Name":null,"BooleanmValue":true},"Children":[{"Type":"BehaviorDesigner.Runtime.Tasks.Selector","NodeData":{"Offset":"(-3.20001221,102.400024)"},"ID":2,"Name":"Selector","Instant":true,"AbortTypeabortType":"LowerPriority","Children":[{"Type":"BehaviorDesigner.Runtime.Tasks.Sequence","NodeData":{"Offset":"(-667.6923,99.9037)"},"ID":3,"Name":"Sequence","Instant":true,"AbortTypeabortType":"LowerPriority","Children":[{"Type":"IsDead","NodeData":{"Offset":"(-64.49997,100.200073)"},"ID":4,"Name":"Is
-        Dead","Instant":true,"SharedFloathealth":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":"health","IsShared":true,"SinglemValue":0}},{"Type":"Die","NodeData":{"Offset":"(55.1000671,100.200012)"},"ID":5,"Name":"Die","Instant":true,"SharedFloathealth":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":"health","IsShared":true,"SinglemValue":0},"SharedGameObjectselfObject":{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":"selfObject","IsShared":true}}]},{"Type":"BehaviorDesigner.Runtime.Tasks.Sequence","NodeData":{"Offset":"(-306.110352,95)"},"ID":6,"Name":"Sequence","Instant":true,"AbortTypeabortType":"LowerPriority","Children":[{"Type":"IsInJumpAttack","NodeData":{"Offset":"(-174.899963,99.4000244)"},"ID":7,"Name":"Is
-        In Jump Attack","Instant":true,"SharedGameObjectselfObject":{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":"selfObject","IsShared":true},"SharedGameObjecttargetObject":{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":"targetObject","IsShared":true},"SharedFloatdetectRange":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":null,"SinglemValue":5},"SharedBoolcanJumpAttack":{"Type":"BehaviorDesigner.Runtime.SharedBool","Name":"canJumpAttack","IsShared":true,"BooleanmValue":false}},{"Type":"JumpAttack","NodeData":{"Offset":"(-49.23913,95)"},"ID":8,"Name":"Jump
-        Attack","Instant":true,"SharedGameObjecttargetObject":{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":"targetObject","IsShared":true},"SharedFloatattackDamage":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":null,"SinglemValue":1},"SharedFloatjumpHeight":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":null,"SinglemValue":2},"SharedFloatjumpDuration":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":null,"SinglemValue":1}},{"Type":"BehaviorDesigner.Runtime.Tasks.Wait","NodeData":{"Offset":"(67.3913,95)"},"ID":9,"Name":"Wait","Instant":true,"SharedFloatwaitTime":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":null,"SinglemValue":0.5},"SharedBoolrandomWait":{"Type":"BehaviorDesigner.Runtime.SharedBool","Name":null,"BooleanmValue":false},"SharedFloatrandomWaitMin":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":null,"SinglemValue":1},"SharedFloatrandomWaitMax":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":null,"SinglemValue":1}}]},{"Type":"BehaviorDesigner.Runtime.Tasks.Sequence","NodeData":{"Offset":"(-0.7999878,96.19998)"},"ID":10,"Name":"Sequence","Instant":true,"AbortTypeabortType":"LowerPriority","Children":[{"Type":"IsInAttackRange","NodeData":{"Offset":"(-104.5,100.200012)"},"ID":11,"Name":"Is
-        In Attack Range","Instant":true,"SharedGameObjectselfObject":{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":"selfObject","IsShared":true},"SharedGameObjecttargetObject":{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":"targetObject","IsShared":true},"SharedFloatattackRange":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":null,"SinglemValue":1.5}},{"Type":"Attack","NodeData":{"Offset":"(25.55542,103.889221)"},"ID":12,"Name":"Attack","Instant":true,"SharedGameObjecttargetObject":{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":"targetObject","IsShared":true},"SharedFloatattackDamage":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":null,"SinglemValue":1}},{"Type":"BehaviorDesigner.Runtime.Tasks.Wait","NodeData":{"Offset":"(141.666565,103.889221)"},"ID":13,"Name":"Wait","Instant":true,"SharedFloatwaitTime":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":null,"SinglemValue":1},"SharedBoolrandomWait":{"Type":"BehaviorDesigner.Runtime.SharedBool","Name":null,"BooleanmValue":false},"SharedFloatrandomWaitMin":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":null,"SinglemValue":1},"SharedFloatrandomWaitMax":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":null,"SinglemValue":1}}]},{"Type":"BehaviorDesigner.Runtime.Tasks.Sequence","NodeData":{"Offset":"(372.254517,96.20004)"},"ID":14,"Name":"Sequence","Instant":true,"AbortTypeabortType":"Both","Children":[{"Type":"IsWithinDistance","NodeData":{"Offset":"(-74.0999756,99.00006)"},"ID":15,"Name":"Is
-        Within Distance","Instant":true,"SharedGameObjectselfObject":{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":"selfObject","IsShared":true},"SharedGameObjecttargetObject":{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":"targetObject","IsShared":true},"SharedFloatdetectRange":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":null,"SinglemValue":5}},{"Type":"FollowPlayer","NodeData":{"Offset":"(84.30005,99)"},"ID":16,"Name":"Follow
-        Player","Instant":true,"SharedGameObjectselfObject":{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":"selfObject","IsShared":true},"SharedGameObjecttargetObject":{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":"targetObject","IsShared":true},"SharedFloatspeed":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":null,"SinglemValue":3},"SharedFloatstoppingDistance":{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":null,"SinglemValue":1.5}}]},{"Type":"Idle","NodeData":{"Offset":"(526.7001,102.600006)"},"ID":17,"Name":"Idle","Instant":true}]}]},"Variables":[{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":"targetObject","IsShared":true},{"Type":"BehaviorDesigner.Runtime.SharedGameObject","Name":"selfObject","IsShared":true},{"Type":"BehaviorDesigner.Runtime.SharedFloat","Name":"health","IsShared":true,"SinglemValue":0},{"Type":"BehaviorDesigner.Runtime.SharedBool","Name":"canJumpAttack","IsShared":true,"BooleanmValue":false}]}'
-      fieldSerializationData:
-        typeName: []
-        fieldNameHash: 
-        startIndex: 
-        dataPosition: 
-        unityObjects: []
-        byteData: 
-        byteDataArray: 
-      Version: 1.7.11
-  gizmoViewMode: 2
-  showBehaviorDesignerGizmo: 1
 --- !u!224 &416583670633183547
 RectTransform:
   m_ObjectHideFlags: 0
@@ -3397,22 +2753,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1 &476663687276974383
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8148288602995587247}
-  m_Layer: 12
-  m_Name: Bip001 Ponytail2
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!222 &476894709516516479
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -3458,27 +2798,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!95 &492108887966395580
-Animator:
-  serializedVersion: 5
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3519210703361510015}
-  m_Enabled: 1
-  m_Avatar: {fileID: 9000000, guid: f34b99ca2454aeb42a316f5fa7a1a5ba, type: 3}
-  m_Controller: {fileID: 9100000, guid: b09b1d06360a46649a1d89657566e341, type: 2}
-  m_CullingMode: 1
-  m_UpdateMode: 0
-  m_ApplyRootMotion: 1
-  m_LinearVelocityBlending: 0
-  m_StabilizeFeet: 0
-  m_WarningMessage: 
-  m_HasTransformHierarchy: 1
-  m_AllowConstantClipSamplingOptimization: 1
-  m_KeepAnimatorStateOnDisable: 0
-  m_WriteDefaultValuesOnDisable: 0
 --- !u!222 &502340348201130972
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -3739,21 +3058,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &564214309146003717
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1531384756029974382}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.0000000023380122, y: 6.6528366e-10, z: 0.0142324995, w: 0.99989873}
-  m_LocalPosition: {x: -0.059660796, y: 0, z: -0.000000009536743}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 7425875644270600660}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!222 &572095847504695885
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -3912,22 +3216,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!1 &659559485608154967
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7208229995167400711}
-  m_Layer: 12
-  m_Name: Bip001 Spine1
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!1 &665880124037510443
 GameObject:
   m_ObjectHideFlags: 0
@@ -4042,22 +3330,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &710860240521744791
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6278449894212725675}
-  m_Layer: 12
-  m_Name: Bip001 L Finger21
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!1 &712361031567076604
 GameObject:
   m_ObjectHideFlags: 0
@@ -4103,22 +3375,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2945216324885186760}
   m_CullTransparentMesh: 1
---- !u!1 &735566449340740394
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1731889353970290534}
-  m_Layer: 12
-  m_Name: L Hand Twist
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!224 &737072926848235255
 RectTransform:
   m_ObjectHideFlags: 0
@@ -4350,22 +3606,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &805339182971007785
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2948366441874856339}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.50000036, y: 0.49999964, z: 0.49999964, w: 0.50000036}
-  m_LocalPosition: {x: -0, y: 1.0323576, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 5167970944585419282}
-  m_Father: {fileID: 6107598435827339350}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!222 &807218666745008465
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -4663,21 +3903,6 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!4 &864951088979762616
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5132276562372701330}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.039396167, y: -0.039899815, z: 0.01944418, w: 0.99823743}
-  m_LocalPosition: {x: 0.02688137, y: 0.0059865187, z: -0.05031372}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2869327454000615801}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!222 &877258656505871448
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -4795,22 +4020,6 @@ RectTransform:
   m_AnchoredPosition: {x: 1392.9, y: -35}
   m_SizeDelta: {x: 52, y: 52}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &920601596048554334
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 67145891722817889}
-  m_Layer: 12
-  m_Name: Bip001 R Clavicle
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!1 &924456943110429088
 GameObject:
   m_ObjectHideFlags: 0
@@ -4904,21 +4113,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &965489804161443410
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3301321841775038588}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.23357454, y: -0.018236715, z: 0.0006646177, w: 0.9721677}
-  m_LocalPosition: {x: -0.15600006, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 7299728072827977614}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &965860031130895728
 GameObject:
   m_ObjectHideFlags: 0
@@ -5067,22 +4261,6 @@ GameObject:
   - component: {fileID: 1278901703693819586}
   m_Layer: 5
   m_Name: KeyImage
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!1 &1014817707020113061
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7738696157126505017}
-  m_Layer: 12
-  m_Name: Bip001 R Finger0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -5310,7 +4488,7 @@ RectTransform:
   m_GameObject: {fileID: 6224416475169325737}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 8087040620543937789}
@@ -5406,22 +4584,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6194376376315315085}
   m_CullTransparentMesh: 1
---- !u!4 &1196819521446902357
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1701182780135865365}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.025022559, y: -0.083486505, z: -0.28600904, w: 0.95425504}
-  m_LocalPosition: {x: -0.089030184, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 4765879660701785225}
-  m_Father: {fileID: 7738696157126505017}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!224 &1203963259121862921
 RectTransform:
   m_ObjectHideFlags: 0
@@ -5754,21 +4916,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1273355127633045747
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3249327246135856548}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7071068, y: 0, z: -0, w: 0.7071068}
-  m_LocalPosition: {x: 0.000000008550996, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6107598435827339350}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!222 &1278901703693819586
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -5924,28 +5071,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6225536410644010589}
   m_CullTransparentMesh: 1
---- !u!195 &1336962427952385496
-NavMeshAgent:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3519210703361510015}
-  m_Enabled: 1
-  m_AgentTypeID: 0
-  m_Radius: 0.5
-  m_Speed: 3.5
-  m_Acceleration: 8
-  avoidancePriority: 50
-  m_AngularSpeed: 120
-  m_StoppingDistance: 0
-  m_AutoTraverseOffMeshLink: 1
-  m_AutoBraking: 1
-  m_AutoRepath: 1
-  m_Height: 2
-  m_BaseOffset: 0
-  m_WalkableMask: 4294967295
-  m_ObstacleAvoidanceType: 4
 --- !u!1 &1337936187161040936
 GameObject:
   m_ObjectHideFlags: 0
@@ -5963,22 +5088,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1342292672624070998
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 9142639088266969757}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.043643616, y: -0.04358013, z: 0.0056761135, w: 0.9980801}
-  m_LocalPosition: {x: -0.25195476, y: -0.032284394, z: -0.032136936}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 8745741632496084343}
-  m_Father: {fileID: 8854289190886994944}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!224 &1358460879084961030
 RectTransform:
   m_ObjectHideFlags: 0
@@ -5988,7 +5097,7 @@ RectTransform:
   m_GameObject: {fileID: 1863486957848868169}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2780244922439183307}
@@ -6070,22 +5179,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4608073295659654311}
   m_CullTransparentMesh: 1
---- !u!1 &1391947813113650070
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1801176966041713716}
-  m_Layer: 12
-  m_Name: Bip001 L Finger1
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!1 &1399077463726570454
 GameObject:
   m_ObjectHideFlags: 0
@@ -6142,22 +5235,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2755731287613482649}
   m_CullTransparentMesh: 1
---- !u!4 &1411158254781098616
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1755162123681119183}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.0047462285, y: -0.048809137, z: -0.0966675, w: 0.99410796}
-  m_LocalPosition: {x: -0.49028715, y: 0.000000009536743, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 7285284285616174594}
-  m_Father: {fileID: 6667982237573724754}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1419177305839825525
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -6227,22 +5304,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!1 &1449906478051923147
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8729423583579900343}
-  m_Layer: 12
-  m_Name: Bip001 R Finger32
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!224 &1457408419049648020
 RectTransform:
   m_ObjectHideFlags: 0
@@ -6384,38 +5445,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1 &1531384756029974382
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 564214309146003717}
-  m_Layer: 12
-  m_Name: Bip001 R Finger42
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &1533557749198662978
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2202134596346661991}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.69004834, y: -0.32528242, z: 0.1802088, w: 0.62092626}
-  m_LocalPosition: {x: -0.097914964, y: 0.027833099, z: -0.091036655}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 6484016729914792986}
-  m_Father: {fileID: 86253843048717131}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!222 &1535692550374335335
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -6538,22 +5567,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 125, y: 125}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!4 &1556164621651787087
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3100331437899748402}
-  serializedVersion: 2
-  m_LocalRotation: {x: -9.260355e-10, y: -9.909563e-11, z: 0.10640312, w: 0.9943231}
-  m_LocalPosition: {x: -0.40958703, y: 0, z: 0.000000019073486}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1865242344811415479}
-  m_Father: {fileID: 1912181832676190497}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!224 &1567017250629358904
 RectTransform:
   m_ObjectHideFlags: 0
@@ -6573,21 +5586,6 @@ RectTransform:
   m_AnchoredPosition: {x: 78, y: 14}
   m_SizeDelta: {x: 360, y: 1061}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!4 &1577689169581529589
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7535354973461854095}
-  serializedVersion: 2
-  m_LocalRotation: {x: -6.303574e-11, y: -0.000000001395561, z: -0.045122743, w: 0.9989815}
-  m_LocalPosition: {x: -0.06972236, y: 0.00000015258789, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 4264448743708683586}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!224 &1583446195783086089
 RectTransform:
   m_ObjectHideFlags: 0
@@ -6712,22 +5710,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 115828520037035169}
   m_CullTransparentMesh: 1
---- !u!4 &1645250698685363477
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3614547243880077862}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.00039778004, y: 0.04361939, z: 0.000017370423, w: 0.9990482}
-  m_LocalPosition: {x: -0.26206845, y: -0.04894684, z: 0.020981349}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 7266717812009726156}
-  m_Father: {fileID: 8854289190886994944}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!224 &1656526344044589187
 RectTransform:
   m_ObjectHideFlags: 0
@@ -7054,22 +6036,6 @@ RectTransform:
   m_AnchoredPosition: {x: -22.4, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &1701182780135865365
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1196819521446902357}
-  m_Layer: 12
-  m_Name: Bip001 R Finger01
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!222 &1701391220433862940
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -7215,21 +6181,6 @@ RectTransform:
   m_AnchoredPosition: {x: -12, y: -10.6}
   m_SizeDelta: {x: 200, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!4 &1731889353970290534
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 735566449340740394}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.7069435, y: 0.055820983, z: 0.0025352878, w: 0.7050593}
-  m_LocalPosition: {x: -0.27036107, y: -0.0072346493, z: -0.007901764}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 7628904877610385984}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1746154467942195390
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -7244,138 +6195,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   slider: {fileID: 0}
   duration: 0.2
---- !u!137 &1752978451412690968
-SkinnedMeshRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3249327246135856548}
-  m_Enabled: 1
-  m_CastShadows: 1
-  m_ReceiveShadows: 1
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 3
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 7893120158540049202, guid: f34b99ca2454aeb42a316f5fa7a1a5ba, type: 3}
-  - {fileID: 3646521077223331696, guid: f34b99ca2454aeb42a316f5fa7a1a5ba, type: 3}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 3
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 0
-  serializedVersion: 2
-  m_Quality: 0
-  m_UpdateWhenOffscreen: 0
-  m_SkinnedMotionVectors: 1
-  m_Mesh: {fileID: -6120738636199475877, guid: f34b99ca2454aeb42a316f5fa7a1a5ba, type: 3}
-  m_Bones:
-  - {fileID: 5611396298416145266}
-  - {fileID: 7208229995167400711}
-  - {fileID: 9193329330102847492}
-  - {fileID: 8886754870005248909}
-  - {fileID: 8051108949750377798}
-  - {fileID: 8661835693889562928}
-  - {fileID: 7628904877610385984}
-  - {fileID: 86253843048717131}
-  - {fileID: 9176209348135143407}
-  - {fileID: 1731889353970290534}
-  - {fileID: 67145891722817889}
-  - {fileID: 2869327454000615801}
-  - {fileID: 6837384140312721178}
-  - {fileID: 864951088979762616}
-  - {fileID: 1815341667656428325}
-  - {fileID: 7299728072827977614}
-  - {fileID: 8854289190886994944}
-  - {fileID: 6865873113517538291}
-  - {fileID: 965489804161443410}
-  - {fileID: 2112606407155861725}
-  - {fileID: 4419611795493434455}
-  - {fileID: 5167970944585419282}
-  - {fileID: 5057885117894317862}
-  - {fileID: 1912181832676190497}
-  - {fileID: 6667982237573724754}
-  - {fileID: 1556164621651787087}
-  - {fileID: 8148288602995587247}
-  - {fileID: 7143454350816583382}
-  - {fileID: 1865242344811415479}
-  - {fileID: 5747555530126619387}
-  - {fileID: 1411158254781098616}
-  - {fileID: 7285284285616174594}
-  - {fileID: 2455183032975858917}
-  - {fileID: 1533557749198662978}
-  - {fileID: 6484016729914792986}
-  - {fileID: 1801176966041713716}
-  - {fileID: 4265917399443336755}
-  - {fileID: 2255631131416199291}
-  - {fileID: 2960015648610644071}
-  - {fileID: 1577689169581529589}
-  - {fileID: 9058271612214787270}
-  - {fileID: 6998669629271623496}
-  - {fileID: 7750101081259307871}
-  - {fileID: 4264448743708683586}
-  - {fileID: 6278449894212725675}
-  - {fileID: 3828395123374368281}
-  - {fileID: 2613890526538917194}
-  - {fileID: 1342292672624070998}
-  - {fileID: 1645250698685363477}
-  - {fileID: 7738696157126505017}
-  - {fileID: 1196819521446902357}
-  - {fileID: 1938500793666302516}
-  - {fileID: 7200523178198332755}
-  - {fileID: 4765879660701785225}
-  - {fileID: 3742278460088640371}
-  - {fileID: 7425875644270600660}
-  - {fileID: 564214309146003717}
-  - {fileID: 6453567680086784419}
-  - {fileID: 7266717812009726156}
-  - {fileID: 8745741632496084343}
-  - {fileID: 3142150831274704801}
-  - {fileID: 8729423583579900343}
-  m_BlendShapeWeights: []
-  m_RootBone: {fileID: 5167970944585419282}
-  m_AABB:
-    m_Center: {x: 0.0003721714, y: -0.024950922, z: 0.00000029802322}
-    m_Extent: {x: 1.0319858, y: 0.21384522, z: 1.3225553}
-  m_DirtyAABB: 0
---- !u!1 &1755162123681119183
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1411158254781098616}
-  m_Layer: 12
-  m_Name: Bip001 R Foot
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!222 &1755839284027791243
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -7618,22 +6437,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1801176966041713716
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1391947813113650070}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.0014778379, y: -0.08031517, z: 0.015614805, w: 0.9966461}
-  m_LocalPosition: {x: -0.24381736, y: -0.04940277, z: -0.08430991}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 4264448743708683586}
-  m_Father: {fileID: 86253843048717131}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!224 &1809633954679880182
 RectTransform:
   m_ObjectHideFlags: 0
@@ -7677,21 +6480,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1815341667656428325
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3521168208652269159}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.040258132, y: -0.00000035617572, z: 0.00000004324503, w: 0.9991893}
-  m_LocalPosition: {x: -0.000000019073486, y: 0, z: 0.00000015258789}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2869327454000615801}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!224 &1817826717563799546
 RectTransform:
   m_ObjectHideFlags: 0
@@ -7921,22 +6709,6 @@ RectTransform:
   m_AnchoredPosition: {x: -5, y: 0}
   m_SizeDelta: {x: -20, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!4 &1865242344811415479
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2265553158853150022}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.0047462187, y: 0.048809048, z: -0.0966675, w: 0.99410796}
-  m_LocalPosition: {x: -0.4902871, y: -0.000000019073486, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 5747555530126619387}
-  m_Father: {fileID: 1556164621651787087}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!222 &1887115725968944164
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -8009,22 +6781,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 67}
   m_SizeDelta: {x: 430, y: 80}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!4 &1912181832676190497
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3657139558709065567}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.009657475, y: 0.9987502, z: -0.00047484788, w: 0.049036272}
-  m_LocalPosition: {x: 0.00000015258789, y: 0.00000017410497, z: 0.09300488}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1556164621651787087}
-  m_Father: {fileID: 5167970944585419282}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1924955348598772742
 GameObject:
   m_ObjectHideFlags: 0
@@ -8041,22 +6797,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &1938500793666302516
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8005625187388059490}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.0014778388, y: 0.08031517, z: 0.015614796, w: 0.9966461}
-  m_LocalPosition: {x: -0.2438174, y: -0.049402922, z: 0.08430991}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 3742278460088640371}
-  m_Father: {fileID: 8854289190886994944}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1943602461197708381
 GameObject:
   m_ObjectHideFlags: 0
@@ -8096,22 +6836,6 @@ GameObject:
   - component: {fileID: 3578355216806784806}
   m_Layer: 5
   m_Name: Text
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!1 &1956380190279898641
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 86253843048717131}
-  m_Layer: 12
-  m_Name: Bip001 L Hand
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -8192,22 +6916,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2223191093502471806}
   m_CullTransparentMesh: 1
---- !u!1 &1982866920065046013
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6998669629271623496}
-  m_Layer: 12
-  m_Name: Bip001 L Finger22
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!114 &1990765126932980195
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -8468,22 +7176,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5394091826692562028}
   m_CullTransparentMesh: 1
---- !u!4 &2112606407155861725
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3389370460151287785}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.000002080476, y: 0.000000693676, z: -0.000398159, w: 0.99999994}
-  m_LocalPosition: {x: -0.106955715, y: -0.00015182186, z: 0.00000014853663}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 7208229995167400711}
-  m_Father: {fileID: 5167970944585419282}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2116427554876545620
 GameObject:
   m_ObjectHideFlags: 0
@@ -8808,22 +7500,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &2202134596346661991
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1533557749198662978}
-  m_Layer: 12
-  m_Name: Bip001 L Finger0
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!1 &2208924655320865038
 GameObject:
   m_ObjectHideFlags: 0
@@ -8943,22 +7619,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6785636757246696147}
   m_CullTransparentMesh: 1
---- !u!4 &2255631131416199291
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6116319332051847644}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.00039778033, y: -0.043619394, z: 0.00001736295, w: 0.9990482}
-  m_LocalPosition: {x: -0.26206833, y: -0.04894684, z: -0.020981358}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 6278449894212725675}
-  m_Father: {fileID: 86253843048717131}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2258046042020218279
 GameObject:
   m_ObjectHideFlags: 0
@@ -8994,22 +7654,6 @@ MonoBehaviour:
   targetOffset: {x: 0, y: 300}
   targetScale: 0
   expText: {fileID: 0}
---- !u!1 &2265553158853150022
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1865242344811415479}
-  m_Layer: 12
-  m_Name: Bip001 L Foot
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!114 &2270141807235194864
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -9032,53 +7676,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2116427554876545620}
   m_CullTransparentMesh: 1
---- !u!114 &2281551077325318616
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3519210703361510015}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: b63c4c4705e46724692cf9a90d004ea8, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  projectilePrefab: {fileID: 0}
-  firePoint: {fileID: 0}
-  stat:
-    Health: 0
-    DamageReducation: 0
-    Damage: 0
-    Angle: 0
-    AttackRange: 0
-    MoveSpeed: 0
-    InAttackRange: 0
-    DetectRange: 0
-    RotateSpeed: 0
-    MaxRotateTime: 0
-    StopDist: 0
-    canJumpAttack: 0
-    jumpHeight: 0
-    jumpDuration: 0
-    changeSpeed: 0
-  type: 3
-  reference:
-    Anim: {fileID: 492108887966395580}
-    Coll: {fileID: 333899169111128897}
-    Rb: {fileID: 8199434030946860284}
-    Nav: {fileID: 1336962427952385496}
-  drag:
-    MaxDuration: 1
-    GatherSpeed: 10
-    GatherRad: 1
-  push:
-    MaxDuration: 1
-    PushDist: 5
-    PushSpeed: 10
-  knock:
-    DownDration: 2
-  attackCount: 0
 --- !u!224 &2291585673830948551
 RectTransform:
   m_ObjectHideFlags: 0
@@ -9166,22 +7763,6 @@ RectTransform:
   m_AnchoredPosition: {x: -0, y: 70}
   m_SizeDelta: {x: 530.314, y: 445.5316}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &2330400669317447940
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7200523178198332755}
-  m_Layer: 12
-  m_Name: Bip001 R Finger4
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!1 &2348607550500227729
 GameObject:
   m_ObjectHideFlags: 0
@@ -9296,22 +7877,6 @@ GameObject:
   - component: {fileID: 5339891337445161694}
   m_Layer: 5
   m_Name: CloseKeyImage
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!1 &2383134390933894130
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7266717812009726156}
-  m_Layer: 12
-  m_Name: Bip001 R Finger21
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -9737,22 +8302,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 665880124037510443}
   m_CullTransparentMesh: 1
---- !u!4 &2455183032975858917
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7733163958156229535}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.043767713, y: 0.10621272, z: 0.00459498, w: 0.9933691}
-  m_LocalPosition: {x: -0.22844215, y: -0.025473326, z: 0.08472616}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 2613890526538917194}
-  m_Father: {fileID: 86253843048717131}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2457291536364240278
 GameObject:
   m_ObjectHideFlags: 0
@@ -9972,22 +8521,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4622987508085297611}
   m_CullTransparentMesh: 1
---- !u!1 &2554667107512834955
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3142150831274704801}
-  m_Layer: 12
-  m_Name: Bip001 R Finger22
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!224 &2567700885625834117
 RectTransform:
   m_ObjectHideFlags: 0
@@ -10145,23 +8678,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &2613890526538917194
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4672928180168382314}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.0000000017112658, y: 0.0000000051748144, z: -0.029395988,
-    w: 0.99956787}
-  m_LocalPosition: {x: -0.05129585, y: 0, z: -0.0000000333786}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 9058271612214787270}
-  m_Father: {fileID: 2455183032975858917}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &2622475078998481639
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -11010,6 +9526,8 @@ MonoBehaviour:
   markerPrefab: {fileID: 4714070860029359875, guid: f108ad7a309762c488e48290e0c288b1,
     type: 3}
   markerTransform: {fileID: 4641623034491320932}
+  skillCountText: {fileID: 0}
+  effect: {fileID: 0}
 --- !u!222 &2841461327116134127
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -11071,24 +9589,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!4 &2869327454000615801
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8388753011759458551}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.038461532, y: 0.07975298, z: -0.038784605, w: 0.99531704}
-  m_LocalPosition: {x: -0.16872495, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 7299728072827977614}
-  - {fileID: 864951088979762616}
-  - {fileID: 1815341667656428325}
-  m_Father: {fileID: 67145891722817889}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!224 &2882864132156597184
 RectTransform:
   m_ObjectHideFlags: 0
@@ -11121,22 +9621,6 @@ GameObject:
   - component: {fileID: 8558899618991653007}
   m_Layer: 5
   m_Name: Fill
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!1 &2901654844861339356
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7299728072827977614}
-  m_Layer: 12
-  m_Name: Bip001 R Forearm
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -11273,22 +9757,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1 &2948366441874856339
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 805339182971007785}
-  m_Layer: 12
-  m_Name: Bip001
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!224 &2958125925030690930
 RectTransform:
   m_ObjectHideFlags: 0
@@ -11309,22 +9777,6 @@ RectTransform:
   m_AnchoredPosition: {x: 28.2033, y: 34.8}
   m_SizeDelta: {x: 592.0375, y: 14.8266}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!4 &2960015648610644071
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4829096215913473162}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.04364362, y: 0.04358013, z: 0.0056761135, w: 0.9980801}
-  m_LocalPosition: {x: -0.25195473, y: -0.03228424, z: 0.032136936}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 3828395123374368281}
-  m_Father: {fileID: 86253843048717131}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &2987563083958109177
 GameObject:
   m_ObjectHideFlags: 0
@@ -11474,7 +9926,7 @@ RectTransform:
   m_GameObject: {fileID: 1964867513459237652}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 5049580543303981347}
@@ -11778,22 +10230,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 0
---- !u!1 &3100331437899748402
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1556164621651787087}
-  m_Layer: 12
-  m_Name: Bip001 L Calf
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!222 &3122745667172162366
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -11847,22 +10283,6 @@ RectTransform:
   m_AnchoredPosition: {x: -22.4, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!4 &3142150831274704801
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2554667107512834955}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.0000000017660201, y: 0.0000000033129741, z: -0.029395986,
-    w: 0.99956787}
-  m_LocalPosition: {x: -0.0888678, y: 0.00000015258789, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 7266717812009726156}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!224 &3149673947217653875
 RectTransform:
   m_ObjectHideFlags: 0
@@ -11872,7 +10292,7 @@ RectTransform:
   m_GameObject: {fileID: 4821602111616259954}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2088148094014170582}
@@ -12065,22 +10485,6 @@ RectTransform:
   m_AnchoredPosition: {x: -12, y: 66.8}
   m_SizeDelta: {x: 200, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &3207596446648666129
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3828395123374368281}
-  m_Layer: 12
-  m_Name: Bip001 L Finger31
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!224 &3210817777671708130
 RectTransform:
   m_ObjectHideFlags: 0
@@ -12251,39 +10655,6 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls: []
---- !u!1 &3231790967304936294
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5611396298416145266}
-  m_Layer: 12
-  m_Name: Bip001 L Clavicle
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!1 &3249327246135856548
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1273355127633045747}
-  - component: {fileID: 1752978451412690968}
-  m_Layer: 12
-  m_Name: Jake
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!1 &3253262224057221062
 GameObject:
   m_ObjectHideFlags: 0
@@ -12374,22 +10745,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1 &3291065528338777393
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7143454350816583382}
-  m_Layer: 12
-  m_Name: Bip001 Neck
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!222 &3296229097037956691
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -12412,22 +10767,6 @@ GameObject:
   - component: {fileID: 6077329638234221162}
   m_Layer: 5
   m_Name: Background
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!1 &3301321841775038588
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 965489804161443410}
-  m_Layer: 12
-  m_Name: Bone013
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -12755,22 +11094,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 10, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &3389370460151287785
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2112606407155861725}
-  m_Layer: 12
-  m_Name: Bip001 Spine
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!1 &3405159505093762489
 GameObject:
   m_ObjectHideFlags: 0
@@ -12902,22 +11225,6 @@ RectTransform:
   m_AnchoredPosition: {x: 30.3, y: 1.3}
   m_SizeDelta: {x: 200, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &3461873528718715239
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4765879660701785225}
-  m_Layer: 12
-  m_Name: Bip001 R Finger02
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!114 &3473484070990445315
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -13011,44 +11318,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6968299048071035648}
   m_CullTransparentMesh: 1
---- !u!1 &3519210703361510015
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6107598435827339350}
-  - component: {fileID: 492108887966395580}
-  - component: {fileID: 2281551077325318616}
-  - component: {fileID: 415924105689620363}
-  - component: {fileID: 1336962427952385496}
-  - component: {fileID: 8199434030946860284}
-  - component: {fileID: 333899169111128897}
-  m_Layer: 12
-  m_Name: EliteMonster1
-  m_TagString: Monster
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 0
---- !u!1 &3521168208652269159
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1815341667656428325}
-  m_Layer: 12
-  m_Name: R Upper Twist
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!224 &3528105591406144318
 RectTransform:
   m_ObjectHideFlags: 0
@@ -13058,7 +11327,7 @@ RectTransform:
   m_GameObject: {fileID: 4608073295659654311}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 3532047459146105843}
@@ -13110,22 +11379,6 @@ RectTransform:
   m_AnchoredPosition: {x: -283, y: 473.9664}
   m_SizeDelta: {x: 1577.3169, y: 1010.856}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &3535027068325725753
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4264448743708683586}
-  m_Layer: 12
-  m_Name: Bip001 L Finger11
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!1 &3545220452705720301
 GameObject:
   m_ObjectHideFlags: 0
@@ -13139,22 +11392,6 @@ GameObject:
   - component: {fileID: 5631376704158444627}
   m_Layer: 5
   m_Name: Deco
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!1 &3556187837914760437
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7628904877610385984}
-  m_Layer: 12
-  m_Name: Bip001 L Forearm
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -13477,22 +11714,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3629107868728280441}
   m_CullTransparentMesh: 1
---- !u!1 &3614547243880077862
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1645250698685363477}
-  m_Layer: 12
-  m_Name: Bip001 R Finger2
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!114 &3622871359988339965
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -13723,22 +11944,6 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!1 &3657139558709065567
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1912181832676190497}
-  m_Layer: 12
-  m_Name: Bip001 L Thigh
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!114 &3661147060831266855
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -14216,23 +12421,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &3742278460088640371
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6645105247358372511}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.000000001907987, y: -0.000000007905436, z: 0.0057315724,
-    w: 0.9999836}
-  m_LocalPosition: {x: -0.054728467, y: -0.00000015258789, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 6453567680086784419}
-  m_Father: {fileID: 1938500793666302516}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!222 &3745101137086914649
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -14309,23 +12497,6 @@ MonoBehaviour:
   selectCallback: {fileID: 0}
   slotButton: {fileID: 8584436514168565057}
   slotNumber: 0
---- !u!4 &3828395123374368281
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3207596446648666129}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.0000000011054154, y: -0.0000000040446606, z: 0.014232522,
-    w: 0.99989873}
-  m_LocalPosition: {x: -0.054576263, y: 0.00000015258789, z: -0.000000002682209}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 7750101081259307871}
-  m_Father: {fileID: 2960015648610644071}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &3836919661219086980
 GameObject:
   m_ObjectHideFlags: 0
@@ -14956,22 +13127,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: a141ee45b29e8ed4a8fb48e58afd3563, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!1 &4065698778203424699
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6667982237573724754}
-  m_Layer: 12
-  m_Name: Bip001 R Calf
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!222 &4089024494118634108
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -15129,7 +13284,7 @@ RectTransform:
   m_GameObject: {fileID: 5725850098138468807}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 3687289420520575585}
@@ -15587,38 +13742,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 275730885271374221}
   m_CullTransparentMesh: 1
---- !u!4 &4264448743708683586
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3535027068325725753}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.0000000019026491, y: 0.0000000069741284, z: 0.0057315724,
-    w: 0.9999836}
-  m_LocalPosition: {x: -0.054728393, y: -0.00000015258789, z: -0.000000019073486}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1577689169581529589}
-  m_Father: {fileID: 1801176966041713716}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &4265917399443336755
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7160133881413102926}
-  serializedVersion: 2
-  m_LocalRotation: {x: 9.740373e-10, y: 0.000000014869291, z: -0.065366544, w: 0.9978613}
-  m_LocalPosition: {x: -0.07129333, y: 0, z: -0.00000015258789}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6484016729914792986}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!224 &4266639975614418724
 RectTransform:
   m_ObjectHideFlags: 0
@@ -15895,7 +14018,7 @@ RectTransform:
   m_GameObject: {fileID: 3488350847201288292}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 3306159142106366810}
@@ -16125,22 +14248,6 @@ RectTransform:
   m_AnchoredPosition: {x: 987.0001, y: -150.00002}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!4 &4419611795493434455
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6392037114861212879}
-  serializedVersion: 2
-  m_LocalRotation: {x: -1.02262275e-10, y: -0.0000007187033, z: 0.174041, w: 0.9847384}
-  m_LocalPosition: {x: -0.06975372, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 8148288602995587247}
-  m_Father: {fileID: 7143454350816583382}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &4426809665510094173
 GameObject:
   m_ObjectHideFlags: 0
@@ -17177,22 +15284,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1265641107837502770}
   m_CullTransparentMesh: 1
---- !u!1 &4672928180168382314
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2613890526538917194}
-  m_Layer: 12
-  m_Name: Bip001 L Finger41
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!224 &4675583019439898798
 RectTransform:
   m_ObjectHideFlags: 0
@@ -17305,22 +15396,6 @@ RectTransform:
   m_AnchoredPosition: {x: -22.4, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &4695953418720836232
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8854289190886994944}
-  m_Layer: 12
-  m_Name: Bip001 R Hand
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!222 &4712797309493513882
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -17511,21 +15586,6 @@ RectTransform:
   m_AnchoredPosition: {x: 176.99995, y: -115.00009}
   m_SizeDelta: {x: 360, y: 1146.709}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!4 &4765879660701785225
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3461873528718715239}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.000000014869291, y: -9.740379e-10, z: -0.06536658, w: 0.9978613}
-  m_LocalPosition: {x: -0.071293406, y: 0, z: 0.00000015258789}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1196819521446902357}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!222 &4767351649824203004
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -17971,22 +16031,6 @@ RectTransform:
   m_AnchoredPosition: {x: -24, y: -78.4}
   m_SizeDelta: {x: 371.9215, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &4829096215913473162
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2960015648610644071}
-  m_Layer: 12
-  m_Name: Bip001 L Finger3
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!222 &4844878605632830400
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -18875,22 +16919,6 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!4 &5057885117894317862
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7414239516954253272}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.009657406, y: 0.99875015, z: 0.0004734771, w: -0.04903775}
-  m_LocalPosition: {x: -0.00000015258789, y: -0.00000008385341, z: -0.09300488}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 6667982237573724754}
-  m_Father: {fileID: 5167970944585419282}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!222 &5069103070384085970
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -19052,22 +17080,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2150194911543515541}
   m_CullTransparentMesh: 1
---- !u!1 &5132276562372701330
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 864951088979762616}
-  m_Layer: 12
-  m_Name: R Deltoid
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!114 &5136505392320779555
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -19208,24 +17220,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5488542019787738942}
   m_CullTransparentMesh: 1
---- !u!4 &5167970944585419282
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6088402918534213033}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.5, y: 0.5, z: 0.4999993, w: 0.5000007}
-  m_LocalPosition: {x: -0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1912181832676190497}
-  - {fileID: 5057885117894317862}
-  - {fileID: 2112606407155861725}
-  m_Father: {fileID: 805339182971007785}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!224 &5174794254247235170
 RectTransform:
   m_ObjectHideFlags: 0
@@ -20028,22 +18022,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1 &5397497758321516732
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8661835693889562928}
-  m_Layer: 12
-  m_Name: L Upper Twist
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!222 &5398170946892546862
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -20174,22 +18152,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!1 &5497847516394544307
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6484016729914792986}
-  m_Layer: 12
-  m_Name: Bip001 L Finger01
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!222 &5501191655036049529
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -20421,22 +18383,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_ShowMaskGraphic: 1
---- !u!1 &5590828334114976358
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 9058271612214787270}
-  m_Layer: 12
-  m_Name: Bip001 L Finger42
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!114 &5596150555484470156
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -20481,23 +18427,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6891686548420319926}
   m_CullTransparentMesh: 1
---- !u!4 &5611396298416145266
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3231790967304936294}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.6755902, y: -0.00027001614, z: 0.7372773, w: -0.00029261538}
-  m_LocalPosition: {x: -0.2759648, y: -0.08085143, z: 0.052866995}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 9193329330102847492}
-  - {fileID: 8886754870005248909}
-  m_Father: {fileID: 7208229995167400711}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &5613688068402003749
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -20695,7 +18624,7 @@ RectTransform:
   m_GameObject: {fileID: 4384149164273844972}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 7760155428841783482}
@@ -20718,22 +18647,6 @@ GameObject:
   - component: {fileID: 5376800231149777828}
   m_Layer: 5
   m_Name: EquipmentPanelText
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!1 &5654904713277696640
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6837384140312721178}
-  m_Layer: 12
-  m_Name: Bone014
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -21147,21 +19060,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &5747555530126619387
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5929479522440777161}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.00000001545431, y: 0.00000001545431, z: -0.7071068, w: 0.7071068}
-  m_LocalPosition: {x: -0.12940529, y: 0.18253753, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1865242344811415479}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &5748146113679653698
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -21987,22 +19885,6 @@ ParticleSystem:
     type: 3}
   m_PrefabInstance: {fileID: 5916175207704884824}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &5929479522440777161
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5747555530126619387}
-  m_Layer: 12
-  m_Name: Bip001 L Toe0
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!114 &5957182239392721180
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -22627,55 +20509,6 @@ RectTransform:
   m_AnchoredPosition: {x: -40, y: -250}
   m_SizeDelta: {x: 1031, y: 504.172}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &6088402918534213033
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5167970944585419282}
-  m_Layer: 12
-  m_Name: Bip001 Pelvis
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &6107598435827339350
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3519210703361510015}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 2.28, y: 0, z: 0}
-  m_LocalScale: {x: 2, y: 2, z: 2}
-  m_ConstrainProportionsScale: 1
-  m_Children:
-  - {fileID: 805339182971007785}
-  - {fileID: 1273355127633045747}
-  m_Father: {fileID: 0}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &6116319332051847644
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2255631131416199291}
-  m_Layer: 12
-  m_Name: Bip001 L Finger2
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!222 &6120667762384862160
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -22987,7 +20820,7 @@ RectTransform:
   m_GameObject: {fileID: 559435007636982102}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 2738122509908694594}
@@ -23109,23 +20942,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &6278449894212725675
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 710860240521744791}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.0000000036652648, y: -0.0000000042435473, z: 0.014232513,
-    w: 0.99989873}
-  m_LocalPosition: {x: -0.04068947, y: 0.00000015258789, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 6998669629271623496}
-  m_Father: {fileID: 2255631131416199291}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!224 &6278648409763616175
 RectTransform:
   m_ObjectHideFlags: 0
@@ -23418,22 +21234,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!1 &6392037114861212879
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4419611795493434455}
-  m_Layer: 12
-  m_Name: Bip001 Head
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!222 &6393808536284252241
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -23514,22 +21314,6 @@ RectTransform:
   m_AnchoredPosition: {x: 234, y: 50}
   m_SizeDelta: {x: 350, y: 70}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &6409003548187103188
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8051108949750377798}
-  m_Layer: 12
-  m_Name: L Deltoid
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!114 &6410797070720069873
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -23625,22 +21409,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1 &6439962102062842784
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 9176209348135143407}
-  m_Layer: 12
-  m_Name: Bone011
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!114 &6447546948084616561
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -23679,21 +21447,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 9202046711669054604}
   m_CullTransparentMesh: 1
---- !u!4 &6453567680086784419
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8650534810728367545}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.0000000037214962, y: 1.6809536e-10, z: -0.04512275, w: 0.9989815}
-  m_LocalPosition: {x: -0.06972252, y: 0.00000015258789, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 3742278460088640371}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &6456326668393324350
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -23822,22 +21575,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3125337063277347079}
   m_CullTransparentMesh: 1
---- !u!4 &6484016729914792986
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5497847516394544307}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.025022576, y: 0.08348649, z: -0.2860091, w: 0.95425504}
-  m_LocalPosition: {x: -0.089030184, y: -0.000000038146972, z: 0.00000015258789}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 4265917399443336755}
-  m_Father: {fileID: 1533557749198662978}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!222 &6491220254436242258
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -24153,22 +21890,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 924456943110429088}
   m_CullTransparentMesh: 1
---- !u!1 &6645105247358372511
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 3742278460088640371}
-  m_Layer: 12
-  m_Name: Bip001 R Finger11
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!1 &6646386332952611498
 GameObject:
   m_ObjectHideFlags: 0
@@ -24276,22 +21997,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!4 &6667982237573724754
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4065698778203424699}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.0000000014556888, y: 0.000000003902333, z: 0.10640311, w: 0.9943231}
-  m_LocalPosition: {x: -0.40958706, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1411158254781098616}
-  m_Father: {fileID: 5057885117894317862}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!222 &6670209493957728839
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -24433,22 +22138,6 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!1 &6691650799855476883
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8886754870005248909}
-  m_Layer: 12
-  m_Name: Bone016
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!1 &6697221059600562079
 GameObject:
   m_ObjectHideFlags: 0
@@ -24528,22 +22217,6 @@ RectTransform:
   m_AnchoredPosition: {x: 1142.9, y: -35}
   m_SizeDelta: {x: 52, y: 52}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &6739915991922418352
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7425875644270600660}
-  m_Layer: 12
-  m_Name: Bip001 R Finger41
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!1 &6755367457314170600
 GameObject:
   m_ObjectHideFlags: 0
@@ -24824,22 +22497,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1 &6828612873590754344
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6865873113517538291}
-  m_Layer: 12
-  m_Name: R Hand Twist
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!114 &6834065723581308250
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -24889,21 +22546,6 @@ RectTransform:
   m_AnchoredPosition: {x: 20, y: 43}
   m_SizeDelta: {x: 1959, y: 516.1749}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!4 &6837384140312721178
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5654904713277696640}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.07266581, y: 0.73464835, z: 0.09549258, w: 0.66775197}
-  m_LocalPosition: {x: -0.16872497, y: -0.000000009536743, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 67145891722817889}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &6837997400560636326
 GameObject:
   m_ObjectHideFlags: 0
@@ -24941,21 +22583,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &6865873113517538291
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6828612873590754344}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.70698804, y: -0.05519932, z: 0.002011691, w: 0.70506525}
-  m_LocalPosition: {x: -0.2703211, y: -0.007223587, z: 0.0077488706}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 7299728072827977614}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &6866074035522162287
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -25488,21 +23115,6 @@ RectTransform:
   m_AnchoredPosition: {x: -12, y: -10.6}
   m_SizeDelta: {x: 200, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!4 &6998669629271623496
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1982866920065046013}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.000000003737369, y: 3.5595143e-10, z: -0.02939598, w: 0.99956787}
-  m_LocalPosition: {x: -0.08886772, y: 0.00000015258789, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 6278449894212725675}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &7026876400159292461
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -25927,22 +23539,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7049821281034328572}
   m_CullTransparentMesh: 1
---- !u!4 &7143454350816583382
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3291065528338777393}
-  serializedVersion: 2
-  m_LocalRotation: {x: 7.606368e-12, y: 0.00000071761593, z: -0.17364827, w: 0.9848077}
-  m_LocalPosition: {x: -0.33116898, y: -0.026568431, z: -0.000000036266393}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 4419611795493434455}
-  m_Father: {fileID: 7208229995167400711}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!224 &7148246526292212145
 RectTransform:
   m_ObjectHideFlags: 0
@@ -25985,22 +23581,6 @@ RectTransform:
   m_AnchoredPosition: {x: -46, y: 13}
   m_SizeDelta: {x: 264.0664, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &7160133881413102926
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 4265917399443336755}
-  m_Layer: 12
-  m_Name: Bip001 L Finger02
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!224 &7189284252261876094
 RectTransform:
   m_ObjectHideFlags: 0
@@ -26106,40 +23686,6 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
---- !u!4 &7200523178198332755
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2330400669317447940}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.043767713, y: -0.10621272, z: 0.0045949803, w: 0.9933691}
-  m_LocalPosition: {x: -0.22844219, y: -0.02547348, z: -0.08472616}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 7425875644270600660}
-  m_Father: {fileID: 8854289190886994944}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &7208229995167400711
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 659559485608154967}
-  serializedVersion: 2
-  m_LocalRotation: {x: -3.0117673e-14, y: 0, z: -0, w: 1}
-  m_LocalPosition: {x: -0.1907276, y: -0.0001993183, z: -5.5282867e-10}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 5611396298416145266}
-  - {fileID: 7143454350816583382}
-  - {fileID: 67145891722817889}
-  m_Father: {fileID: 2112606407155861725}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &7209217770939417783
 GameObject:
   m_ObjectHideFlags: 0
@@ -26255,22 +23801,6 @@ RectTransform:
   m_AnchoredPosition: {x: -1.961792, y: 0.3729}
   m_SizeDelta: {x: 3.9236, y: 7.295}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!4 &7266717812009726156
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2383134390933894130}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.0000000037315404, y: -4.1259393e-10, z: 0.014232498, w: 0.99989873}
-  m_LocalPosition: {x: -0.040689543, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 3142150831274704801}
-  m_Father: {fileID: 1645250698685363477}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!222 &7269151930215180294
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -26327,21 +23857,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &7285284285616174594
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8932993129635915417}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.000000015454312, y: -0.000000015454312, z: -0.7071068, w: 0.7071068}
-  m_LocalPosition: {x: -0.12940529, y: 0.18253753, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 1411158254781098616}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!224 &7286257392352450180
 RectTransform:
   m_ObjectHideFlags: 0
@@ -26361,24 +23876,6 @@ RectTransform:
   m_AnchoredPosition: {x: -12, y: -10.6}
   m_SizeDelta: {x: 200, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!4 &7299728072827977614
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2901654844861339356}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.0000000028205611, y: 0.000000014749863, z: 0.0645453, w: 0.9979148}
-  m_LocalPosition: {x: -0.27714464, y: -0.000000019073486, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 8854289190886994944}
-  - {fileID: 965489804161443410}
-  - {fileID: 6865873113517538291}
-  m_Father: {fileID: 2869327454000615801}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!224 &7303958234333727239
 RectTransform:
   m_ObjectHideFlags: 0
@@ -26797,39 +24294,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1 &7414239516954253272
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5057885117894317862}
-  m_Layer: 12
-  m_Name: Bip001 R Thigh
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &7425875644270600660
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6739915991922418352}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.0000000026045421, y: -0.0000000064822063, z: -0.029395986,
-    w: 0.99956787}
-  m_LocalPosition: {x: -0.05129585, y: 0, z: 0.000000014305114}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 564214309146003717}
-  m_Father: {fileID: 7200523178198332755}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &7437118352942798570
 GameObject:
   m_ObjectHideFlags: 0
@@ -27314,22 +24778,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!1 &7535354973461854095
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1577689169581529589}
-  m_Layer: 12
-  m_Name: Bip001 L Finger12
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!224 &7543102639529225545
 RectTransform:
   m_ObjectHideFlags: 0
@@ -27820,24 +25268,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 881568356950356002}
   m_CullTransparentMesh: 1
---- !u!4 &7628904877610385984
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3556187837914760437}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.0000000046793223, y: -0.000000014629638, z: 0.06454531, w: 0.9979148}
-  m_LocalPosition: {x: -0.27714464, y: 0, z: 0.00000015258789}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 86253843048717131}
-  - {fileID: 9176209348135143407}
-  - {fileID: 1731889353970290534}
-  m_Father: {fileID: 9193329330102847492}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &7632081667042305368
 GameObject:
   m_ObjectHideFlags: 0
@@ -27852,22 +25282,6 @@ GameObject:
   - component: {fileID: 2622475078998481639}
   m_Layer: 5
   m_Name: ItemSlot
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!1 &7634548589913945291
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 9193329330102847492}
-  m_Layer: 12
-  m_Name: Bip001 L UpperArm
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -28236,22 +25650,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 3388027823101041975}
   m_CullTransparentMesh: 1
---- !u!1 &7733163958156229535
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2455183032975858917}
-  m_Layer: 12
-  m_Name: Bip001 L Finger4
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!1 &7736567750645736006
 GameObject:
   m_ObjectHideFlags: 0
@@ -28270,37 +25668,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!4 &7738696157126505017
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1014817707020113061}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.69004834, y: 0.32528242, z: 0.1802088, w: 0.62092626}
-  m_LocalPosition: {x: -0.097915, y: 0.027833099, z: 0.09103664}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1196819521446902357}
-  m_Father: {fileID: 8854289190886994944}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &7750101081259307871
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8122498971728652743}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.00000000150419, y: 3.3540043e-10, z: -0.029395996, w: 0.99956787}
-  m_LocalPosition: {x: -0.073653564, y: 0.00000015258789, z: 0.000000012218952}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 3828395123374368281}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &7756476782111377849
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -28659,6 +26026,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   selectedButton: {fileID: 1068081022450940045}
+  exitChoiceButton: {fileID: 0}
+  exitChoicePanel: {fileID: 0}
 --- !u!224 &7865777587672835224
 RectTransform:
   m_ObjectHideFlags: 0
@@ -29200,22 +26569,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1 &8005625187388059490
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1938500793666302516}
-  m_Layer: 12
-  m_Name: Bip001 R Finger1
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!224 &8011136011443821813
 RectTransform:
   m_ObjectHideFlags: 0
@@ -29392,21 +26745,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!4 &8051108949750377798
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6409003548187103188}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.039397564, y: 0.039866958, z: 0.019428391, w: 0.998239}
-  m_LocalPosition: {x: 0.026881197, y: 0.0059859273, z: 0.050314177}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 9193329330102847492}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!224 &8076026098060352035
 RectTransform:
   m_ObjectHideFlags: 0
@@ -29576,22 +26914,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!1 &8122498971728652743
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7750101081259307871}
-  m_Layer: 12
-  m_Name: Bip001 L Finger32
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!222 &8127230514271383352
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -29666,21 +26988,6 @@ MonoBehaviour:
   selectCallback: {fileID: 0}
   slotButton: {fileID: 4569274887160536342}
   slotNumber: 0
---- !u!4 &8148288602995587247
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 476663687276974383}
-  serializedVersion: 2
-  m_LocalRotation: {x: -1.7522207e-12, y: -0.0000024314645, z: 0.87664604, w: -0.4811359}
-  m_LocalPosition: {x: -0.025943298, y: 0.028906697, z: -0.0000001932972}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 4419611795493434455}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!224 &8154753881217358314
 RectTransform:
   m_ObjectHideFlags: 0
@@ -29767,33 +27074,6 @@ RectTransform:
   m_AnchoredPosition: {x: -84.10004, y: 0}
   m_SizeDelta: {x: 128.2, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!54 &8199434030946860284
-Rigidbody:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 3519210703361510015}
-  serializedVersion: 4
-  m_Mass: 1
-  m_Drag: 0
-  m_AngularDrag: 0.05
-  m_CenterOfMass: {x: 0, y: 0, z: 0}
-  m_InertiaTensor: {x: 1, y: 1, z: 1}
-  m_InertiaRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ImplicitCom: 1
-  m_ImplicitTensor: 1
-  m_UseGravity: 0
-  m_IsKinematic: 1
-  m_Interpolate: 0
-  m_Constraints: 84
-  m_CollisionDetection: 0
 --- !u!114 &8200952964038680751
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -30323,22 +27603,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8545137734379714287}
   m_CullTransparentMesh: 1
---- !u!1 &8388753011759458551
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 2869327454000615801}
-  m_Layer: 12
-  m_Name: Bip001 R UpperArm
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!114 &8392608953378695372
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -31647,37 +28911,6 @@ RectTransform:
   m_AnchoredPosition: {x: -15, y: 192}
   m_SizeDelta: {x: 485.336, y: 114.432}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &8650534810728367545
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 6453567680086784419}
-  m_Layer: 12
-  m_Name: Bip001 R Finger12
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &8661835693889562928
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5397497758321516732}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.040258124, y: 0.00000032112757, z: -0.000000012227629, w: 0.9991893}
-  m_LocalPosition: {x: -0.000000019073486, y: 0, z: -0.00000015258789}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 9193329330102847492}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!222 &8688885180048857728
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -31727,37 +28960,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6186585683873450651}
   m_CullTransparentMesh: 1
---- !u!4 &8729423583579900343
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1449906478051923147}
-  serializedVersion: 2
-  m_LocalRotation: {x: 5.518935e-10, y: -0.000000004995137, z: -0.029396, w: 0.99956787}
-  m_LocalPosition: {x: -0.07365364, y: 0.00000015258789, z: -0.000000002682209}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 8745741632496084343}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!4 &8745741632496084343
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8854835605871251516}
-  serializedVersion: 2
-  m_LocalRotation: {x: 9.335065e-10, y: -1.4679978e-10, z: 0.014232524, w: 0.99989873}
-  m_LocalPosition: {x: -0.054576263, y: -0.00000015258789, z: 0.0000000023841857}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 8729423583579900343}
-  m_Father: {fileID: 1342292672624070998}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!222 &8757841311367292996
 CanvasRenderer:
   m_ObjectHideFlags: 0
@@ -32151,42 +29353,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!4 &8854289190886994944
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 4695953418720836232}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.706812, y: -0.057182718, z: 0.0044404515, w: 0.70507246}
-  m_LocalPosition: {x: -0.36577564, y: -0.000000019073486, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 7738696157126505017}
-  - {fileID: 1938500793666302516}
-  - {fileID: 1645250698685363477}
-  - {fileID: 1342292672624070998}
-  - {fileID: 7200523178198332755}
-  m_Father: {fileID: 7299728072827977614}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &8854835605871251516
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 8745741632496084343}
-  m_Layer: 12
-  m_Name: Bip001 R Finger31
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!224 &8858261927591667163
 RectTransform:
   m_ObjectHideFlags: 0
@@ -32341,21 +29507,6 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!4 &8886754870005248909
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6691650799855476883}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.07282609, y: -0.7345513, z: 0.09568532, w: 0.66781366}
-  m_LocalPosition: {x: -0.16872495, y: -0.000000009536743, z: -0.00000015258789}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 5611396298416145266}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!224 &8887523879313518115
 RectTransform:
   m_ObjectHideFlags: 0
@@ -32404,22 +29555,6 @@ GameObject:
   - component: {fileID: 5991464679707811969}
   m_Layer: 5
   m_Name: TraitExplain
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!1 &8932993129635915417
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 7285284285616174594}
-  m_Layer: 12
-  m_Name: Bip001 R Toe0
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -32702,22 +29837,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 294372930097183829}
   m_CullTransparentMesh: 1
---- !u!4 &9058271612214787270
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 5590828334114976358}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.0000000024589644, y: -0.000000009162742, z: 0.014232513,
-    w: 0.99989873}
-  m_LocalPosition: {x: -0.059660643, y: 0.00000015258789, z: 0.000000028610229}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2613890526538917194}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &9058701390747464494
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -32920,22 +30039,6 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!1 &9142639088266969757
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1342292672624070998}
-  m_Layer: 12
-  m_Name: Bip001 R Finger3
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
 --- !u!224 &9170218120598050272
 RectTransform:
   m_ObjectHideFlags: 0
@@ -32985,21 +30088,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!4 &9176209348135143407
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 6439962102062842784}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0.23356031, y: 0.018442173, z: 0.0008376181, w: 0.9721671}
-  m_LocalPosition: {x: -0.15599999, y: 0, z: -0.00000030517577}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 7628904877610385984}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!224 &9179106889014206967
 RectTransform:
   m_ObjectHideFlags: 0
@@ -33085,24 +30173,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 6553241700001457388}
   m_CullTransparentMesh: 1
---- !u!4 &9193329330102847492
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 7634548589913945291}
-  serializedVersion: 2
-  m_LocalRotation: {x: 0.038461532, y: -0.07975298, z: -0.03878461, w: 0.99531704}
-  m_LocalPosition: {x: -0.16872495, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 7628904877610385984}
-  - {fileID: 8051108949750377798}
-  - {fileID: 8661835693889562928}
-  m_Father: {fileID: 5611396298416145266}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &9202046711669054604
 GameObject:
   m_ObjectHideFlags: 0
@@ -33172,6 +30242,5 @@ SceneRoots:
   - {fileID: 2230928614706467294}
   - {fileID: 1733108820}
   - {fileID: 2924293503788284681}
-  - {fileID: 6107598435827339350}
   - {fileID: 733339011}
-  - {fileID: 379252664}
+  - {fileID: 2002474798}

--- a/Assets/2.Private/LimJH/Scripts/BaseMonster.cs
+++ b/Assets/2.Private/LimJH/Scripts/BaseMonster.cs
@@ -26,7 +26,7 @@ public class BaseMonster : MonoBehaviour, IDamagable, IPushable, IPooledObject
 
     [SerializeField] private E_Monster type = E_Monster.None;
 
-    private ProjectPlayer player;
+    public ProjectPlayer player;
 
     #region Injects
 

--- a/Assets/2.Private/LimJH/Scripts/Behavior Tree/JumpAttack.cs
+++ b/Assets/2.Private/LimJH/Scripts/Behavior Tree/JumpAttack.cs
@@ -12,6 +12,8 @@ public class JumpAttack : BaseAction
     {
         base.OnStart();
 
+        init = transform.rotation.eulerAngles;
+        
         if (mob == null)
         {
             Debug.LogWarning("몬스터가 존재하지 않습니다.");
@@ -27,7 +29,15 @@ public class JumpAttack : BaseAction
         //                              transform.position.y + mob.Stat.jumpHeight,
         //                              mob.PlayerPos.z);
 
-                                     targetPosition = mob.PlayerPos;
+        targetPosition = mob.PlayerPos;
+
+        /*// 충돌 방지 설정
+        Collider mobCollider = mob.GetComponent<Collider>();
+        Collider playerCollider = mob.player.GetComponent<Collider>();
+        if (mobCollider != null && playerCollider != null)
+        {
+            Physics.IgnoreCollision(mobCollider, playerCollider, true); // 충돌 비활성화
+        }*/
 
         // 점프 애니메이션 트리거 추가 가능
         Debug.Log("점프 시작!");
@@ -38,6 +48,9 @@ public class JumpAttack : BaseAction
             mob.Stat.canJumpAttack = false; // 점프 공격 비활성화
         }
     }
+
+    Vector3 temp;
+    Vector3 init;
 
     public override TaskStatus OnUpdate()
     {
@@ -51,6 +64,11 @@ public class JumpAttack : BaseAction
         elapsedTime += Time.deltaTime;
         float progress = elapsedTime / mob.Stat.jumpDuration;
 
+        if (progress > 0 && progress <= 0.1)
+        {
+            transform.rotation = Quaternion.RotateTowards(transform.rotation, Quaternion.Euler(init.x + 1,init.y,init.z), Time.deltaTime * 100);
+        }
+
         // 점프 곡선 (포물선 형태)
         Vector3 currentPosition = Vector3.Lerp(startPosition, targetPosition, progress);
         currentPosition.y += Mathf.Sin(progress * Mathf.PI) * mob.Stat.jumpHeight;
@@ -59,8 +77,15 @@ public class JumpAttack : BaseAction
         // 점프 완료
         if (progress >= 1f)
         {
-            //공격처리
+            /*// 충돌 복구
+            Collider mobCollider = mob.GetComponent<Collider>();
+            Collider playerCollider = mob.player.GetComponent<Collider>();
+            if (mobCollider != null && playerCollider != null)
+            {
+                Physics.IgnoreCollision(mobCollider, playerCollider, false); // 충돌 활성화
+            }*/
 
+            //공격처리
             return TaskStatus.Success;
         }
 


### PR DESCRIPTION
- 점프 공격 몬스터가 점프공격을 실행할 때 약간의 회전값을 줘서 플레이어가 땅을 뚫는 현상을 수정